### PR TITLE
fix: (#27) 소켓 연결 아키텍처 개선 및 대기실 UI 연동 오류 수정

### DIFF
--- a/src/app/socketProvider.tsx
+++ b/src/app/socketProvider.tsx
@@ -1,6 +1,7 @@
 import type { ChatMessage } from '@/shared/model/types';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { io, Socket } from 'socket.io-client';
+import { io } from '@/shared/api/socket';
+import type { Socket } from '@/shared/api/socket';
 import { useAuthStore } from '@/features/auth/model/useAuthStore';
 import { SocketContext } from '@/shared/api/socket/socketContext';
 
@@ -33,6 +34,8 @@ export const SocketProvider = ({ children }: { children: React.ReactNode }) => {
     }
 
     const socket = socketRef.current;
+
+    if (!socket) return;
 
     const handleConnect = () => setIsConnected(true);
     const handleDisconnect = () => setIsConnected(false);

--- a/src/entities/chat/model/useGameChat.ts
+++ b/src/entities/chat/model/useGameChat.ts
@@ -1,37 +1,32 @@
 import { useState, useEffect, useRef } from 'react';
 import type { KeyboardEvent } from 'react';
-import { getSocket } from '@/shared/api/socket';
+import { useSocket } from '@/shared/api/socket/socketContext';
 import type { ChatMessage } from '@/shared/model/types';
-
-const MY_USER_ID = 'id-1234';
+import { useAuthStore } from '@/features/auth';
 
 export const useGameChat = () => {
+  const { socket } = useSocket();
+
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState('');
   const [isComposing, setIsComposing] = useState(false);
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
+  const MY_USER_ID = useAuthStore((state) => state.user?.id);
 
   useEffect(() => {
-    const socket = getSocket();
+    if (!socket) return;
 
-    const handleNewMessage = (newMsg: any) => {
-      const formattedMsg: ChatMessage = {
-        id: newMsg.id || Date.now().toString(),
-        senderId: newMsg.senderId,
-        nickname: newMsg.senderName,
-        message: newMsg.content,
-        channel: '전체',
-      };
-      setMessages((prev) => [...prev, formattedMsg]);
+    const handleNewMessage = (newMsg: ChatMessage) => {
+      setMessages((prev) => [...prev, newMsg]);
     };
 
-    socket.on('chatMessage', handleNewMessage);
+    socket.on('chat:newMessage', handleNewMessage);
 
     return () => {
-      socket.off('chatMessage', handleNewMessage);
+      socket.off('chat:newMessage', handleNewMessage);
     };
-  }, []);
+  }, [socket]);
 
   useEffect(() => {
     messagesEndRef.current?.scrollTo({
@@ -41,9 +36,9 @@ export const useGameChat = () => {
   }, [messages]);
 
   const handleSendMessage = () => {
-    if (!input.trim()) return;
+    if (!input.trim() || !socket) return;
 
-    getSocket().emit('sendChat', {
+    socket.emit('chat:sendMessage', {
       userId: MY_USER_ID,
       message: input,
     });
@@ -52,7 +47,8 @@ export const useGameChat = () => {
   };
 
   const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter' && !isComposing) {
+    if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
+      e.preventDefault();
       handleSendMessage();
     }
   };

--- a/src/entities/chat/model/useMainChat.ts
+++ b/src/entities/chat/model/useMainChat.ts
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from 'react';
 import type { Friend } from '@/shared/model/types';
 import { mockChannels, mockFriends } from '@/mocks/chat.mock';
 import { useSocket } from '@/shared/api/socket/socketContext';
+import { useAuthStore } from '@/features/auth';
 
 export const useMainChat = () => {
   const { messages, sendMessage: emitMessage } = useSocket();
@@ -15,6 +16,8 @@ export const useMainChat = () => {
   const [isComposing, setIsComposing] = useState(false);
 
   const [isChannelDropdownOpen, setIsChannelDropdownOpen] = useState(false);
+
+  const userId = useAuthStore((state) => state.user?.id);
 
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
 
@@ -156,5 +159,6 @@ export const useMainChat = () => {
     selectChannel,
     onChannelToggle,
     handleSelectChannel,
+    userId,
   };
 };

--- a/src/entities/chat/ui/MainChat.tsx
+++ b/src/entities/chat/ui/MainChat.tsx
@@ -4,7 +4,6 @@ import { ChannelSelect } from './ChannelSelect';
 import { ChatInput } from './ChatInput';
 import { ChatSendButton } from './ChatSendButton';
 import { MentionDropdown } from './MentionDropdown';
-import { useAuthStore } from '@/features/auth';
 
 export const MainChat = () => {
   const {
@@ -23,9 +22,8 @@ export const MainChat = () => {
     isChannelDropdownOpen,
     onChannelToggle,
     handleSelectChannel,
+    userId,
   } = useMainChat();
-
-  const myId = useAuthStore((state) => state.user?.id);
 
   const disableSend =
     input.trim() === '' || /^@[a-zA-Z0-9가-힣_]+$/.test(input.trim());
@@ -35,7 +33,7 @@ export const MainChat = () => {
       <MessageList
         messages={messages}
         messagesEndRef={messagesEndRef}
-        currentUserId={myId}
+        currentUserId={userId}
         showChannelTag={true}
       />
 

--- a/src/entities/chat/ui/MessageItem.tsx
+++ b/src/entities/chat/ui/MessageItem.tsx
@@ -35,6 +35,8 @@ export const MessageItem = ({
     );
   }
 
+  console.log('sender: ' + msg.senderId);
+  console.log('current: ' + currentUserId);
   return (
     <p className={containerClassName}>
       {showTag && <span className="font-bold text-[20px] mr-1">[전체]</span>}

--- a/src/entities/chat/ui/MessageItem.tsx
+++ b/src/entities/chat/ui/MessageItem.tsx
@@ -35,8 +35,6 @@ export const MessageItem = ({
     );
   }
 
-  console.log('sender: ' + msg.senderId);
-  console.log('current: ' + currentUserId);
   return (
     <p className={containerClassName}>
       {showTag && <span className="font-bold text-[20px] mr-1">[전체]</span>}

--- a/src/features/lobby/model/useRoom.ts
+++ b/src/features/lobby/model/useRoom.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router';
-import { getSocket } from '@/shared/api/socket';
+import { useSocket } from '@/shared/api/socket/socketContext';
 import type { RoomState } from '@/entities/game/model/types';
 import {
   selectCanStartGame,
@@ -12,25 +12,28 @@ import { useAuthStore } from '@/features/auth/model/useAuthStore';
 export const useRoom = () => {
   const { roomId } = useParams();
   const { user } = useAuthStore();
+  const { socket } = useSocket();
+
   const myUserId = user?.id;
   const [roomState, setRoomState] = useState<RoomState | null>(null);
 
   useEffect(() => {
-    if (!roomId) return;
-
-    const socket = getSocket();
+    if (!roomId || !socket) return;
 
     const handleGameState = (newState: RoomState) => {
+      console.log('[Client] 방 상태 수신:', newState);
       setRoomState(newState);
     };
 
-    socket.emit('joinRoom', { roomId });
-    socket.on('gameState', handleGameState);
+    socket.on('room:stateSync', handleGameState);
+
+    socket.emit('room:join', { roomId });
 
     return () => {
-      socket.off('gameState', handleGameState);
+      socket.off('room:stateSync', handleGameState);
+      socket.emit('room:leave');
     };
-  }, [roomId]);
+  }, [roomId, socket]);
 
   const me = selectMe(roomState, myUserId ?? '');
   const isSolo = roomState?.settings?.gameMode === 'SOLO';
@@ -42,26 +45,29 @@ export const useRoom = () => {
   const canStartGame = selectCanStartGame(roomState);
 
   const startGame = () => {
-    if (!roomId) return;
-    getSocket().emit('startGame', { roomId });
+    if (!roomId || !socket) return;
+    socket.emit('room:start', { roomId });
   };
 
   const toggleReady = () => {
-    if (!me || !myUserId) return;
-    getSocket().emit('toggleReady', { userId: myUserId });
+    if (!me || !myUserId || !socket) return;
+    socket.emit('room:readyToggle', { userId: myUserId });
   };
 
   const leaveRoom = () => {
-    if (!myUserId) return;
-    getSocket().emit('leaveRoom', { userId: myUserId });
+    if (!myUserId || !socket) return;
+    socket.emit('room:leave');
   };
 
   const changeTeam = (targetTeam: 'BLUE' | 'RED') => {
-    if (!myUserId) return;
+    if (!myUserId || !socket) return;
     if (me?.teamId === targetTeam) return;
-    getSocket().emit('changeTeam', { userId: myUserId, teamId: targetTeam });
 
-    // 낙관적 업데이트
+    socket.emit('room:changeTeam', {
+      userId: myUserId,
+      targetTeamId: targetTeam,
+    });
+
     setRoomState((prev) => {
       if (!prev) return null;
       return {
@@ -73,8 +79,9 @@ export const useRoom = () => {
     });
   };
 
-  const kickUser = (targetId: string) => {
-    getSocket().emit('kickUser', { targetId });
+  const kickUser = (targetUserId: string) => {
+    if (!socket) return;
+    socket.emit('room:kickUser', { targetUserId });
   };
 
   return {

--- a/src/features/lobby/model/useRoom.ts
+++ b/src/features/lobby/model/useRoom.ts
@@ -21,7 +21,6 @@ export const useRoom = () => {
     if (!roomId || !socket) return;
 
     const handleGameState = (newState: RoomState) => {
-      console.log('[Client] 방 상태 수신:', newState);
       setRoomState(newState);
     };
 

--- a/src/mocks/game.mock.ts
+++ b/src/mocks/game.mock.ts
@@ -1,7 +1,7 @@
 import type { RoomState, Player } from '@/entities/game/model/types';
 
 const MOCK_ME: Player = {
-  userId: 'id-1234',
+  userId: 'id-2',
   nickname: '밥아저씨',
   level: 30,
   outfit: [
@@ -102,7 +102,7 @@ const MOCK_BONUS: Player = {
 
 export const MOCK_ROOM_STATE: RoomState = {
   roomStatus: 'waiting',
-  hostId: 'id-1234',
+  hostId: 'user-leaver-111',
   timer: null,
   players: [MOCK_ME, MOCK_OPPONENT, MOCK_DISCONNECTED, MOCK_BONUS],
   settings: {

--- a/src/shared/api/socket/constants.ts
+++ b/src/shared/api/socket/constants.ts
@@ -1,0 +1,20 @@
+export const SOCKET_EVENTS = {
+  CONNECT: 'connect',
+  DISCONNECT: 'disconnect',
+
+  LOBBY_SEND: 'lobby:send',
+  LOBBY_MESSAGE: 'lobby:message',
+
+  ROOM_STATE_SYNC: 'room:stateSync',
+  ROOM_JOIN: 'room:join',
+  ROOM_READY_TOGGLE: 'room:readyToggle',
+  ROOM_CHANGE_TEAM: 'room:changeTeam',
+  ROOM_KICK_USER: 'room:kickUser',
+  ROOM_LEAVE: 'room:leave',
+
+  CHAT_SEND_MESSAGE: 'chat:sendMessage',
+  CHAT_NEW_MESSAGE: 'chat:newMessage',
+} as const;
+
+export type SocketEventName =
+  (typeof SOCKET_EVENTS)[keyof typeof SOCKET_EVENTS];

--- a/src/shared/api/socket/index.ts
+++ b/src/shared/api/socket/index.ts
@@ -1,23 +1,18 @@
-import { io, Socket } from 'socket.io-client';
+import { io as realIo, Socket as RealSocket } from 'socket.io-client';
+import type { ManagerOptions, SocketOptions } from 'socket.io-client';
 import { MockSocket } from './mockSocket';
 
-let socketInstance: Socket | MockSocket | null = null;
+export type Socket = RealSocket;
 
-export const getSocket = () => {
-  if (socketInstance) return socketInstance;
-
+export const io = (
+  uri: string,
+  opts?: Partial<ManagerOptions & SocketOptions>,
+): RealSocket => {
   const useMock = import.meta.env.VITE_USE_MOCK === 'true';
 
   if (useMock) {
-    socketInstance = new MockSocket();
-  } else {
-    socketInstance = io(
-      import.meta.env.VITE_API_URL || 'http://localhost:3000',
-      {
-        transports: ['websocket'],
-      },
-    );
+    return new MockSocket() as unknown as RealSocket;
   }
 
-  return socketInstance;
+  return realIo(uri, opts);
 };

--- a/src/shared/api/socket/mockSocket.ts
+++ b/src/shared/api/socket/mockSocket.ts
@@ -1,12 +1,12 @@
 import type { RoomState } from '@/entities/game/model';
 import { MOCK_ROOM_STATE } from '@/mocks/game.mock';
+import { SOCKET_EVENTS } from '@/shared/api/socket/constants';
 
 type Listener = (...args: any[]) => void;
 
 export class MockSocket {
   private listeners: Record<string, Listener[]> = {};
   private roomState: RoomState;
-
   public connected: boolean = false;
   public auth: { token?: string } = {};
 
@@ -19,14 +19,14 @@ export class MockSocket {
     if (this.connected) return;
     this.connected = true;
     setTimeout(() => {
-      this.trigger('connect');
-      this.trigger('room:stateSync', this.roomState);
+      this.trigger(SOCKET_EVENTS.CONNECT);
+      this.trigger(SOCKET_EVENTS.ROOM_STATE_SYNC, this.roomState);
     }, 100);
   }
 
   disconnect() {
     this.connected = false;
-    this.trigger('disconnect');
+    this.trigger(SOCKET_EVENTS.DISCONNECT);
   }
 
   on(event: string, callback: Listener) {
@@ -47,86 +47,116 @@ export class MockSocket {
     }
   }
 
-  emit(event: string, ...args: any[]) {
-    const payload = args[0] || {};
-
-    if (event === 'lobby:send') {
-      const { message } = payload;
-
-      const mainChatMsg = {
-        id: Date.now().toString(),
-        senderId: 'test-user',
-        nickname: '테스트유저(Mock1)',
-        message: message,
-      };
-      this.trigger('lobby:message', mainChatMsg);
-    }
-
-    if (event === 'room:join') {
-      this.broadcastRoomState();
-    }
-
-    if (event === 'room:readyToggle') {
-      const userId = payload.userId || this.roomState.players[0]?.userId;
-
-      const player = this.roomState.players.find((p) => p.userId === userId);
-      if (player) {
-        player.isReady = !player.isReady;
-        this.broadcastRoomState();
-      }
-    }
-
-    if (event === 'room:changeTeam') {
-      const { targetTeamId, userId } = payload;
-      const targetUser = userId || this.roomState.players[0]?.userId;
-
-      const player = this.roomState.players.find(
-        (p) => p.userId === targetUser,
-      );
-      if (player) {
-        player.teamId = targetTeamId;
-        player.isReady = false;
-        this.broadcastRoomState();
-      }
-    }
-
-    if (event === 'room:kickUser') {
-      const { targetUserId } = payload;
-      this.roomState.players = this.roomState.players.filter(
-        (p) => p.userId !== targetUserId,
-      );
-      this.broadcastRoomState();
-    }
-
-    if (event === 'room:leave') {
-      console.log('[Mock] 유저 퇴장');
-    }
-
-    if (event === 'chat:sendMessage') {
-      const { message, userId } = payload;
-      const sender =
-        this.roomState.players.find((p) => p.userId === userId) ||
-        this.roomState.players[0];
-
-      const newChatMessage = {
-        id: Date.now().toString(),
-        senderId: sender?.userId,
-        nickname: sender?.nickname,
-        message: message,
-      };
-
-      this.trigger('chat:newMessage', newChatMessage);
-    }
-  }
-
   private broadcastRoomState() {
     const newState = JSON.parse(JSON.stringify(this.roomState));
-    this.trigger('room:stateSync', newState);
+    this.trigger(SOCKET_EVENTS.ROOM_STATE_SYNC, newState);
   }
 
   private trigger(event: string, ...args: any[]) {
     if (this.listeners[event]) {
       this.listeners[event].forEach((cb) => cb(...args));
     }
+  }
+
+  emit(event: string, ...args: any[]) {
+    const payload = args[0] || {};
+
+    switch (event) {
+      case SOCKET_EVENTS.LOBBY_SEND:
+        this.handleLobbySend(payload);
+        break;
+
+      case SOCKET_EVENTS.ROOM_JOIN:
+        this.handleRoomJoin();
+        break;
+
+      case SOCKET_EVENTS.ROOM_READY_TOGGLE:
+        this.handleRoomReadyToggle(payload);
+        break;
+
+      case SOCKET_EVENTS.ROOM_CHANGE_TEAM:
+        this.handleRoomChangeTeam(payload);
+        break;
+
+      case SOCKET_EVENTS.ROOM_KICK_USER:
+        this.handleRoomKickUser(payload);
+        break;
+
+      case SOCKET_EVENTS.ROOM_LEAVE:
+        this.handleRoomLeave();
+        break;
+
+      case SOCKET_EVENTS.CHAT_SEND_MESSAGE:
+        this.handleChatSendMessage(payload);
+        break;
+
+      default:
+        break;
+    }
+  }
+
+  private handleLobbySend(payload: any) {
+    const { message } = payload;
+    const mainChatMsg = {
+      id: Date.now().toString(),
+      senderId: 'test-user',
+      nickname: '테스트유저(Mock1)',
+      message: message,
+    };
+    this.trigger(SOCKET_EVENTS.LOBBY_MESSAGE, mainChatMsg);
+  }
+
+  private handleRoomJoin() {
+    this.broadcastRoomState();
+  }
+
+  private handleRoomReadyToggle(payload: any) {
+    const userId = payload.userId || this.roomState.players[0]?.userId;
+    const player = this.roomState.players.find((p) => p.userId === userId);
+
+    if (player) {
+      player.isReady = !player.isReady;
+      this.broadcastRoomState();
+    }
+  }
+
+  private handleRoomChangeTeam(payload: any) {
+    const { targetTeamId, userId } = payload;
+    const targetUser = userId || this.roomState.players[0]?.userId;
+    const player = this.roomState.players.find((p) => p.userId === targetUser);
+
+    if (player) {
+      player.teamId = targetTeamId;
+      player.isReady = false;
+      this.broadcastRoomState();
+    }
+  }
+
+  private handleRoomKickUser(payload: any) {
+    const { targetUserId } = payload;
+    this.roomState.players = this.roomState.players.filter(
+      (p) => p.userId !== targetUserId,
+    );
+    this.broadcastRoomState();
+  }
+
+  private handleRoomLeave() {
+    // TODO: 유저 방 나가기 처리
+  }
+
+  private handleChatSendMessage(payload: any) {
+    const { message, userId } = payload;
+    const sender =
+      this.roomState.players.find((p) => p.userId === userId) ||
+      this.roomState.players[0];
+
+    const newChatMessage = {
+      id: Date.now().toString(),
+      senderId: sender?.userId,
+      nickname: sender?.nickname,
+      message: message,
+    };
+
+    this.trigger(SOCKET_EVENTS.CHAT_NEW_MESSAGE, newChatMessage);
   }
 }

--- a/src/shared/api/socket/mockSocket.ts
+++ b/src/shared/api/socket/mockSocket.ts
@@ -1,6 +1,15 @@
 import type { RoomState } from '@/entities/game/model';
 import { MOCK_ROOM_STATE } from '@/mocks/game.mock';
 import { SOCKET_EVENTS } from '@/shared/api/socket/constants';
+import {
+  handleLobbySend,
+  handleRoomJoin,
+  handleRoomReadyToggle,
+  handleRoomChangeTeam,
+  handleRoomKickUser,
+  handleRoomLeave,
+  handleChatSendMessage,
+} from './socketHandlers';
 
 type Listener = (...args: any[]) => void;
 
@@ -47,12 +56,12 @@ export class MockSocket {
     }
   }
 
-  private broadcastRoomState() {
+  public broadcastRoomState() {
     const newState = JSON.parse(JSON.stringify(this.roomState));
     this.trigger(SOCKET_EVENTS.ROOM_STATE_SYNC, newState);
   }
 
-  private trigger(event: string, ...args: any[]) {
+  public trigger(event: string, ...args: any[]) {
     if (this.listeners[event]) {
       this.listeners[event].forEach((cb) => cb(...args));
     }
@@ -63,100 +72,35 @@ export class MockSocket {
 
     switch (event) {
       case SOCKET_EVENTS.LOBBY_SEND:
-        this.handleLobbySend(payload);
+        handleLobbySend(this, payload);
         break;
 
       case SOCKET_EVENTS.ROOM_JOIN:
-        this.handleRoomJoin();
+        handleRoomJoin(this);
         break;
 
       case SOCKET_EVENTS.ROOM_READY_TOGGLE:
-        this.handleRoomReadyToggle(payload);
+        handleRoomReadyToggle(this, payload);
         break;
 
       case SOCKET_EVENTS.ROOM_CHANGE_TEAM:
-        this.handleRoomChangeTeam(payload);
+        handleRoomChangeTeam(this, payload);
         break;
 
       case SOCKET_EVENTS.ROOM_KICK_USER:
-        this.handleRoomKickUser(payload);
+        handleRoomKickUser(this, payload);
         break;
 
       case SOCKET_EVENTS.ROOM_LEAVE:
-        this.handleRoomLeave();
+        handleRoomLeave(this);
         break;
 
       case SOCKET_EVENTS.CHAT_SEND_MESSAGE:
-        this.handleChatSendMessage(payload);
+        handleChatSendMessage(this, payload);
         break;
 
       default:
         break;
     }
-  }
-
-  private handleLobbySend(payload: any) {
-    const { message } = payload;
-    const mainChatMsg = {
-      id: Date.now().toString(),
-      senderId: 'test-user',
-      nickname: '테스트유저(Mock1)',
-      message: message,
-    };
-    this.trigger(SOCKET_EVENTS.LOBBY_MESSAGE, mainChatMsg);
-  }
-
-  private handleRoomJoin() {
-    this.broadcastRoomState();
-  }
-
-  private handleRoomReadyToggle(payload: any) {
-    const userId = payload.userId || this.roomState.players[0]?.userId;
-    const player = this.roomState.players.find((p) => p.userId === userId);
-
-    if (player) {
-      player.isReady = !player.isReady;
-      this.broadcastRoomState();
-    }
-  }
-
-  private handleRoomChangeTeam(payload: any) {
-    const { targetTeamId, userId } = payload;
-    const targetUser = userId || this.roomState.players[0]?.userId;
-    const player = this.roomState.players.find((p) => p.userId === targetUser);
-
-    if (player) {
-      player.teamId = targetTeamId;
-      player.isReady = false;
-      this.broadcastRoomState();
-    }
-  }
-
-  private handleRoomKickUser(payload: any) {
-    const { targetUserId } = payload;
-    this.roomState.players = this.roomState.players.filter(
-      (p) => p.userId !== targetUserId,
-    );
-    this.broadcastRoomState();
-  }
-
-  private handleRoomLeave() {
-    // TODO: 유저 방 나가기 처리
-  }
-
-  private handleChatSendMessage(payload: any) {
-    const { message, userId } = payload;
-    const sender =
-      this.roomState.players.find((p) => p.userId === userId) ||
-      this.roomState.players[0];
-
-    const newChatMessage = {
-      id: Date.now().toString(),
-      senderId: sender?.userId,
-      nickname: sender?.nickname,
-      message: message,
-    };
-
-    this.trigger(SOCKET_EVENTS.CHAT_NEW_MESSAGE, newChatMessage);
   }
 }

--- a/src/shared/api/socket/mockSocket.ts
+++ b/src/shared/api/socket/mockSocket.ts
@@ -7,13 +7,26 @@ export class MockSocket {
   private listeners: Record<string, Listener[]> = {};
   private roomState: RoomState;
 
+  public connected: boolean = false;
+  public auth: { token?: string } = {};
+
   constructor() {
     this.roomState = JSON.parse(JSON.stringify(MOCK_ROOM_STATE));
+    this.connect();
+  }
 
+  connect() {
+    if (this.connected) return;
+    this.connected = true;
     setTimeout(() => {
       this.trigger('connect');
-      this.trigger('gameState', this.roomState);
-    }, 500);
+      this.trigger('room:stateSync', this.roomState);
+    }, 100);
+  }
+
+  disconnect() {
+    this.connected = false;
+    this.trigger('disconnect');
   }
 
   on(event: string, callback: Listener) {
@@ -35,46 +48,80 @@ export class MockSocket {
   }
 
   emit(event: string, ...args: any[]) {
-    if (event === 'toggleReady') {
-      const { userId } = args[0];
+    const payload = args[0] || {};
+
+    if (event === 'lobby:send') {
+      const { message } = payload;
+
+      const mainChatMsg = {
+        id: Date.now().toString(),
+        senderId: 'test-user',
+        nickname: '테스트유저(Mock1)',
+        message: message,
+      };
+      this.trigger('lobby:message', mainChatMsg);
+    }
+
+    if (event === 'room:join') {
+      this.broadcastRoomState();
+    }
+
+    if (event === 'room:readyToggle') {
+      const userId = payload.userId || this.roomState.players[0]?.userId;
+
       const player = this.roomState.players.find((p) => p.userId === userId);
       if (player) {
         player.isReady = !player.isReady;
-        const newState = JSON.parse(JSON.stringify(this.roomState));
-        this.trigger('gameState', newState);
+        this.broadcastRoomState();
       }
     }
 
-    if (event === 'kickUser') {
-      const { targetId } = args[0];
-      this.roomState.players = this.roomState.players.filter(
-        (p) => p.userId !== targetId,
+    if (event === 'room:changeTeam') {
+      const { targetTeamId, userId } = payload;
+      const targetUser = userId || this.roomState.players[0]?.userId;
+
+      const player = this.roomState.players.find(
+        (p) => p.userId === targetUser,
       );
-      const newState = JSON.parse(JSON.stringify(this.roomState));
-      this.trigger('gameState', newState);
+      if (player) {
+        player.teamId = targetTeamId;
+        player.isReady = false;
+        this.broadcastRoomState();
+      }
     }
 
-    if (event === 'sendChat') {
-      const { message, userId } = args[0];
+    if (event === 'room:kickUser') {
+      const { targetUserId } = payload;
+      this.roomState.players = this.roomState.players.filter(
+        (p) => p.userId !== targetUserId,
+      );
+      this.broadcastRoomState();
+    }
 
-      const sender = this.roomState.players.find((p) => p.userId === userId);
-      const nickname = sender ? sender.nickname : '알 수 없음';
-      const level = sender ? sender.level : 0;
-      const teamId = sender ? sender.teamId : null;
+    if (event === 'room:leave') {
+      console.log('[Mock] 유저 퇴장');
+    }
 
-      const newMessage = {
+    if (event === 'chat:sendMessage') {
+      const { message, userId } = payload;
+      const sender =
+        this.roomState.players.find((p) => p.userId === userId) ||
+        this.roomState.players[0];
+
+      const newChatMessage = {
         id: Date.now().toString(),
-        senderId: userId,
-        senderName: nickname,
-        content: message,
-        timestamp: new Date().toISOString(),
-        level: level,
-        teamId: teamId,
-        type: 'USER',
+        senderId: sender?.userId,
+        nickname: sender?.nickname,
+        message: message,
       };
 
-      this.trigger('chatMessage', newMessage);
+      this.trigger('chat:newMessage', newChatMessage);
     }
+  }
+
+  private broadcastRoomState() {
+    const newState = JSON.parse(JSON.stringify(this.roomState));
+    this.trigger('room:stateSync', newState);
   }
 
   private trigger(event: string, ...args: any[]) {

--- a/src/shared/api/socket/socketHandlers.ts
+++ b/src/shared/api/socket/socketHandlers.ts
@@ -1,0 +1,71 @@
+import { SOCKET_EVENTS } from '@/shared/api/socket/constants';
+import type { MockSocket } from './mockSocket';
+
+export function handleLobbySend(socket: MockSocket, payload: any) {
+  const { message } = payload;
+  const mainChatMsg = {
+    id: Date.now().toString(),
+    senderId: 'test-user',
+    nickname: '테스트유저(Mock1)',
+    message: message,
+  };
+  socket['trigger'](SOCKET_EVENTS.LOBBY_MESSAGE, mainChatMsg);
+}
+
+export function handleRoomJoin(socket: MockSocket) {
+  socket['broadcastRoomState']();
+}
+
+export function handleRoomReadyToggle(socket: MockSocket, payload: any) {
+  const userId = payload.userId || socket['roomState'].players[0]?.userId;
+  const player = socket['roomState'].players.find(
+    (p: any) => p.userId === userId,
+  );
+
+  if (player) {
+    player.isReady = !player.isReady;
+    socket['broadcastRoomState']();
+  }
+}
+
+export function handleRoomChangeTeam(socket: MockSocket, payload: any) {
+  const { targetTeamId, userId } = payload;
+  const targetUser = userId || socket['roomState'].players[0]?.userId;
+  const player = socket['roomState'].players.find(
+    (p: any) => p.userId === targetUser,
+  );
+
+  if (player) {
+    player.teamId = targetTeamId;
+    player.isReady = false;
+    socket['broadcastRoomState']();
+  }
+}
+
+export function handleRoomKickUser(socket: MockSocket, payload: any) {
+  const { targetUserId } = payload;
+  socket['roomState'].players = socket['roomState'].players.filter(
+    (p: any) => p.userId !== targetUserId,
+  );
+  socket['broadcastRoomState']();
+}
+
+export function handleRoomLeave(socket: MockSocket) {
+  socket.broadcastRoomState();
+}
+
+export function handleChatSendMessage(socket: MockSocket, payload: any) {
+  const { message, userId } = payload;
+  const sender =
+    socket['roomState'].players.find((p: any) => p.userId === userId) ||
+    socket['roomState'].players[0];
+
+  const newChatMessage = {
+    id: Date.now().toString(),
+    senderId: sender?.userId,
+    nickname: sender?.nickname,
+    message: message,
+  };
+
+  socket['trigger'](SOCKET_EVENTS.CHAT_NEW_MESSAGE, newChatMessage);
+}


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- 이번에는 팀 바꾸기 UI 버그 픽스로 시작한 작업이지만, 처음 이슈를 생성했을 때와 달리 채팅 기능 구현(#30)을 진행하면서 작성해두었던 socket을 사용하지 않는 등 다양한 문제가 존재했습니다.
- 해당 문제를 해결함과 동시에 앞으로 원활히 사용할 수 있도록 리팩터링 진행하였습니다.
- `shared/api/socket/mockSocket.ts`: 리팩토링된 Switch-Case 구조와 이벤트 핸들링 로직이 적절한지 피드백을 부탁드립니다!
- `shared/api/socket/constants.ts`: 파일의 위치와, 상수 분리가 적절한지 피드백을 부탁드립니다.

```
(2025/12/09 추가) 확인 결과 더 많은 문제들이 있었고, 이슈 이름을 수정했습니다.

- 기존: 팀 바꾸기 UI 미작동 에러 ->
- 현재: 소켓 연결 아키텍처 개선 및 대기실 UI 연동 오류 수정

- (2025/12/09 추가) 확인된 문제는 다음과 같습니다.
- 채팅 작동을 위해 작성한 socketProvider.tsx가 mockSocket을 무시하고, https://github.com/modern-agile-team/10term-pollycasso-front/pull/30 에서 socket-io의 라이브러리 사용하도록 작성됨.
- 같은 이벤트에 각기 다른 이벤트 이름을 사용함.
- on -> emit이 아닌 emit -> on의 구조를 사용하고 있었음.
- 더미 데이터와, 로컬 스토리지에 저장된 유저 아이디를 다르게 적었음.
- 정확한 타입의 통일이 안 되어 있었음.
```

## ✨ 변경 사항 (Changes)

- 개발 환경에서 `mockSocket`을 사용하도록 작성했습니다.
- 같은 이벤트에 각기 다른 이벤트 이름을 사용하고 있었으나, API 명세서에 정의해둔대로 이벤트 이름을 수정했습니다.
- on 이후 emit을 사용하도록 구조를 변경했습니다.
- 더미 데이터와 로컬 스토리지에 저장된 유저 아이디를 일치하게 변경했습니다.
- 정의해둔 타입대로 코드에서의 사용을 통일시켰습니다.

## 📸 스크린샷 (Screenshots)

<img width="1822" height="1106" alt="image" src="https://github.com/user-attachments/assets/7bfc76c3-0990-42ec-98d7-5ebaf9be3643" />
<img width="1822" height="1106" alt="image" src="https://github.com/user-attachments/assets/1d70ef17-91a1-43c7-bbbc-6f9989c29c16" />


## ✅ 리뷰어 체크리스트 (Reviewer Checklist)

- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?

## 📢 참고 사항 (Notes)

- 참고 사항 기재

## 🧐 이슈 (Related Issues)

- Closes #27 
