### PR TITLE
feat: (#47) 로딩 위젯 구현

### DIFF
--- a/src/app/Router.tsx
+++ b/src/app/Router.tsx
@@ -8,6 +8,8 @@ const SignUpPage = lazy(() => import('@/pages/SignUpPage'));
 const WelcomePage = lazy(() => import('@/pages/WelcomePage'));
 const MainPage = lazy(() => import('@/pages/MainPage'));
 const RoomPage = lazy(() => import('@/pages/RoomPage'));
+// TODO: 다음 위젯(그림 페이즈) 작업 시 삭제 예정
+const LoadingPage = lazy(() => import('@/widgets/game-loading'));
 
 const router = createBrowserRouter([
   {
@@ -39,6 +41,10 @@ const router = createBrowserRouter([
           {
             path: '/rooms/:roomId',
             element: <RoomPage />,
+          },
+          {
+            path: '/dev/loading',
+            element: <LoadingPage />,
           },
         ],
       },

--- a/src/widgets/game-loading/index.tsx
+++ b/src/widgets/game-loading/index.tsx
@@ -1,0 +1,15 @@
+import { useCountdown } from './ui/useCountdown';
+import { GameCountdownView } from './ui/GameCountdownView';
+
+interface GameLoadingProps {
+  duration?: number;
+  onFinished?: () => void;
+}
+
+const GameLoading = ({ duration = 5, onFinished }: GameLoadingProps) => {
+  const count = useCountdown(duration, onFinished);
+
+  return <GameCountdownView count={count} />;
+};
+
+export default GameLoading;

--- a/src/widgets/game-loading/ui/GameCountdownView.tsx
+++ b/src/widgets/game-loading/ui/GameCountdownView.tsx
@@ -1,0 +1,59 @@
+import { motion } from 'framer-motion';
+import { Title } from '@/assets';
+
+interface Props {
+  count: number;
+}
+
+const getCountColor = (num: number) => {
+  if (num >= 3) return '#00AD66';
+  if (num === 2) return '#FF7452';
+  return '#FF3434';
+};
+
+const popAnimation = {
+  initial: { scale: 0.5, opacity: 0 },
+  animate: { scale: 1, opacity: 1 },
+  transition: {
+    duration: 0.4,
+    ease: [0.175, 0.885, 0.32, 1.275] as const,
+  },
+};
+
+export const GameCountdownView = ({ count }: Props) => {
+  return (
+    <div className="flex flex-col items-center justify-center w-full h-screen z-50 fixed inset-0">
+      <div className="rounded-full bg-white w-[250px] h-[250px] shadow-md flex items-center justify-center"></div>
+
+      <div className="mt-10 text-center font-ssrm font-bold flex flex-col items-center">
+        <div className="grid place-items-center h-20 w-full mt-1">
+          <motion.p
+            className="col-start-1 row-start-1 text-5xl text-gray-800"
+            animate={{ opacity: count > 0 ? 1 : 0 }}
+            transition={{ duration: 0.2 }}
+          >
+            게임 시작까지
+          </motion.p>
+
+          {count === 0 && (
+            <motion.img
+              src={Title}
+              alt="Pollycasso"
+              className="col-start-1 row-start-1 h-16 object-contain mb-4"
+              {...popAnimation}
+            />
+          )}
+        </div>
+
+        <motion.p
+          key={count}
+          className="mt-5 text-6xl origin-center"
+          style={{ color: getCountColor(count) }}
+          {...popAnimation}
+        >
+          {count > 0 ? count : 'GO!!'}
+        </motion.p>
+      </div>
+    </div>
+  );
+};

--- a/src/widgets/game-loading/ui/useCountdown.ts
+++ b/src/widgets/game-loading/ui/useCountdown.ts
@@ -1,0 +1,27 @@
+import { useState, useEffect, useRef } from 'react';
+
+export const useCountdown = (duration: number, callback?: () => void) => {
+  const [count, setCount] = useState(duration);
+  const callbackRef = useRef(callback);
+
+  useEffect(() => {
+    callbackRef.current = callback;
+  }, [callback]);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setCount((prev) => {
+        if (prev <= 1) {
+          clearInterval(interval);
+          if (callbackRef.current) callbackRef.current();
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [duration]);
+
+  return count;
+};


### PR DESCRIPTION
## 📝 작업 내용 (Description)

![F4BBAA78-A32D-4C62-8231-A20F9E0F695B_1_201_a](https://github.com/user-attachments/assets/26922b7b-1994-439c-a79f-4b79523596d2)

- 로비(#20) 이후 게임 관련 첫번째 작업입니다.
- FSD 구조에 기반하여 한번 생각을 해봤습니다! **(피드백 부탁드립니다!!!)**
- 게임화면을 `Page`로 잡았습니다.
- 대기실, 로딩, 게임 이 세 개의 화면을 `Widget`으로 잡고, 게임화면인 `Page`를 컨테이너로 활용해 소켓과 내부 정보들을 다루려 합니다.

## ✨ 변경 사항 (Changes)

- `widget` Layer에 `game-loading` slice 추가

## 📸 스크린샷 (Screenshots)
![Dec-12-2025 19-47-56](https://github.com/user-attachments/assets/e8fd243b-fe4e-4d5c-814a-ad0ccfceb5c6)

## ✅ 리뷰어 체크리스트 (Reviewer Checklist)

- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?

## 📢 참고 사항 (Notes)

- 없음

## 🧐 이슈 (Related Issues)

- Closes #47 
