### PR TITLE
publish: (#58) 게임 공통 및 그리기(Drawing) 페이즈 UI 디자인 반영

### DIFF
--- a/src/entities/game/ui/ItemIcon.tsx
+++ b/src/entities/game/ui/ItemIcon.tsx
@@ -39,7 +39,7 @@ export const ItemIcon = ({
     >
       <div
         className={cn(
-          'relative w-[70px] h-[70px] rounded-full mx-auto shadow-md',
+          'relative w-[70px] h-[70px] rounded-full mx-auto',
           'flex items-center justify-center font-bold text-sm select-none',
           'transition-transform duration-200',
           isOwned
@@ -59,6 +59,8 @@ export const ItemIcon = ({
             {name}
           </span>
         )}
+
+        <div className="absolute inset-0 rounded-full shadow-inner shadow-black/30 pointer-events-none" />
 
         {isOwned && (
           <span className="absolute -bottom-1 -right-1 bg-blue-600 text-white text-[10px] px-1.5 py-0.5 rounded-full border border-white shadow-sm z-10">

--- a/src/entities/game/ui/PlayerAvatar.tsx
+++ b/src/entities/game/ui/PlayerAvatar.tsx
@@ -18,7 +18,7 @@ export const PlayerAvatar = ({
       !isConnected ? 'grayscale opacity-50' : ''
     }`}
   >
-    <div className="relative w-[70px] h-[70px] bg-white rounded-full mx-auto shadow-md">
+    <div className="relative w-[70px] h-[70px] bg-white rounded-full mx-auto shadow-inner shadow-black/40">
       <div
         className={`absolute -top-2 -left-2 w-8 h-8 rounded-full border-2 border-[#003D00] ${getLevelColor(level)}`}
       />

--- a/src/entities/game/ui/PlayerAvatar.tsx
+++ b/src/entities/game/ui/PlayerAvatar.tsx
@@ -27,9 +27,5 @@ export const PlayerAvatar = ({
     <p className="text-center mt-2 text-white font-bold truncate w-20">
       {nickname}
     </p>
-
-    {!isConnected && (
-      <span className="text-xs text-red-300 font-bold mt-1">OFFLINE</span>
-    )}
   </div>
 );

--- a/src/entities/game/ui/PlayerAvatar.tsx
+++ b/src/entities/game/ui/PlayerAvatar.tsx
@@ -7,18 +7,29 @@ const getLevelColor = (level: number) => {
 export const PlayerAvatar = ({
   nickname,
   level,
+  isConnected,
 }: {
   nickname: string;
   level: number;
+  isConnected: boolean;
 }) => (
-  <div className="flex flex-col items-center">
+  <div
+    className={`flex flex-col items-center transition-all duration-300 ${
+      !isConnected ? 'grayscale opacity-50' : ''
+    }`}
+  >
     <div className="relative w-[70px] h-[70px] bg-white rounded-full mx-auto shadow-md">
       <div
         className={`absolute -top-2 -left-2 w-8 h-8 rounded-full border-2 border-[#003D00] ${getLevelColor(level)}`}
       />
     </div>
+
     <p className="text-center mt-2 text-white font-bold truncate w-20">
       {nickname}
     </p>
+
+    {!isConnected && (
+      <span className="text-xs text-red-300 font-bold mt-1">OFFLINE</span>
+    )}
   </div>
 );

--- a/src/features/game/constants/game.ts
+++ b/src/features/game/constants/game.ts
@@ -7,6 +7,7 @@ export const COLORS = {
   TIMER_RED: '#F20000',
   NOTICE_BG: '#D9D9D9',
   NOTICE_TEXT: '#000000',
+  BADGE_PINK: '#E597FF',
 };
 
 export const GAME_CONFIG = { MAX_TIME: 90, ITEMS_PER_PAGE: 5 };

--- a/src/features/game/constants/game.ts
+++ b/src/features/game/constants/game.ts
@@ -3,6 +3,8 @@ import type { ItemMeta } from '@/entities/game';
 export const COLORS = {
   PRIMARY_DARK: '#003D00',
   TIMER_GREEN: '#0ABC22',
+  TIMER_YELLOW: '#FFE100',
+  TIMER_RED: '#F20000',
   NOTICE_BG: '#D9D9D9',
   NOTICE_TEXT: '#000000',
 };

--- a/src/features/game/index.ts
+++ b/src/features/game/index.ts
@@ -1,5 +1,6 @@
 export * from './constants/game';
 export { GameCanvas } from './ui/GameCanvas';
 export { GameHeader } from './ui/GameHeader';
+export { GameSubmitButton } from './ui/GameSubmitButton';
 export { InventoryPanel } from './ui/InventoryPanel';
 export { PlayerSidebar } from './ui/PlayerSidebar';

--- a/src/features/game/ui/GameHeader.tsx
+++ b/src/features/game/ui/GameHeader.tsx
@@ -29,7 +29,7 @@ export const GameHeader = ({ currentTheme, endsAt }: GameHeaderProps) => {
 
   return (
     <>
-      <div className="mt-4 py-2 text-black bg-[#D9D9D9]/45">
+      <div className="mt-4 py-2 text-black bg-[#D9D9D9]/45 shadow-sm shadow-black/40">
         <Marquee gradient={false} speed={50}>
           <span className="mx-4 font-bold">{UI_TEXT.NOTICE}</span>
         </Marquee>

--- a/src/features/game/ui/GameHeader.tsx
+++ b/src/features/game/ui/GameHeader.tsx
@@ -31,7 +31,7 @@ export const GameHeader = ({ currentTheme, endsAt }: GameHeaderProps) => {
     <>
       <div className="mt-4 py-2 text-black bg-[#D9D9D9]/45 shadow-sm shadow-black/40">
         <Marquee gradient={false} speed={50}>
-          <span className="mx-4 font-bold">{UI_TEXT.NOTICE}</span>
+          <span className="text-lg mx-4 font-bold">{UI_TEXT.NOTICE}</span>
         </Marquee>
       </div>
 

--- a/src/features/game/ui/GameHeader.tsx
+++ b/src/features/game/ui/GameHeader.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import Marquee from 'react-fast-marquee';
 
 import { COLORS, GAME_CONFIG, UI_TEXT } from '../constants/game';
@@ -10,18 +11,25 @@ interface GameHeaderProps {
 
 export const GameHeader = ({ currentTheme, endsAt }: GameHeaderProps) => {
   const timeLeft = useGameTimer(endsAt);
+
   const timeProgress = (timeLeft / GAME_CONFIG.MAX_TIME) * 100;
+
+  const timerColor = useMemo(() => {
+    const ratio = timeLeft / GAME_CONFIG.MAX_TIME;
+
+    if (ratio <= 1 / 3) return COLORS.TIMER_RED;
+    if (ratio <= 2 / 3) return COLORS.TIMER_YELLOW;
+    return COLORS.TIMER_GREEN;
+  }, [timeLeft]);
+
   const timerStyle = {
-    background: `conic-gradient(${COLORS.TIMER_GREEN} ${timeProgress}%, transparent 0)`,
+    background: `conic-gradient(${timerColor} ${timeProgress}%, transparent 0)`,
     transform: 'scaleX(-1)',
   };
 
   return (
     <>
-      <div
-        className="mt-4 py-2 bg-opacity-50 text-black"
-        style={{ backgroundColor: COLORS.NOTICE_BG }}
-      >
+      <div className="mt-4 py-2 text-black bg-[#D9D9D9]/45">
         <Marquee gradient={false} speed={50}>
           <span className="mx-4 font-bold">{UI_TEXT.NOTICE}</span>
         </Marquee>
@@ -37,12 +45,15 @@ export const GameHeader = ({ currentTheme, endsAt }: GameHeaderProps) => {
         <div className="flex justify-end mr-2">
           <div className="flex flex-col items-center gap-1 pt-2">
             <div
-              className="w-14 h-14 rounded-full bg-white shadow-sm border transition-all duration-300"
-              style={{ ...timerStyle, borderColor: COLORS.TIMER_GREEN }}
+              className="w-14 h-14 rounded-full bg-white shadow-sm border transition-colors duration-300"
+              style={{
+                ...timerStyle,
+                borderColor: timerColor,
+              }}
             />
             <span
-              className="font-bold text-lg font-ssrm"
-              style={{ color: COLORS.TIMER_GREEN }}
+              className="font-bold text-lg font-ssrm transition-colors duration-300"
+              style={{ color: timerColor }}
             >
               {timeLeft}s
             </span>

--- a/src/features/game/ui/GameSubmitButton.tsx
+++ b/src/features/game/ui/GameSubmitButton.tsx
@@ -1,0 +1,35 @@
+import { cn } from '@/shared/lib';
+import { COLORS, UI_TEXT } from '../constants/game';
+
+interface GameSubmitButtonProps {
+  onComplete?: () => void;
+  completedCount: number;
+  totalCount: number;
+}
+
+export const GameSubmitButton = ({
+  onComplete,
+  completedCount,
+  totalCount,
+}: GameSubmitButtonProps) => {
+  return (
+    <div className="relative w-full mt-4">
+      <div
+        className="absolute left-1/2 -translate-x-1/2 -top-7 px-6 py-2 rounded-t-xl text-white font-bold text-sm shadow-md flex items-center justify-center z-0 whitespace-nowrap"
+        style={{ backgroundColor: COLORS.BADGE_PINK }}
+      >
+        {completedCount}/{totalCount} 완료
+      </div>
+      <button
+        onClick={onComplete}
+        className={cn(
+          'relative z-10 w-[110%] -left-[5%] h-16 rounded-full text-2xl font-extrabold shadow-lg',
+          'hover:brightness-95 transition-all active:scale-95',
+          'bg-white text-black',
+        )}
+      >
+        {UI_TEXT.BTN_COMPLETE}
+      </button>
+    </div>
+  );
+};

--- a/src/features/game/ui/GameSubmitButton.tsx
+++ b/src/features/game/ui/GameSubmitButton.tsx
@@ -5,7 +5,7 @@ interface GameSubmitButtonProps {
   onComplete?: () => void;
   completedCount: number;
   totalCount: number;
-  isReady: boolean; // 상태 추가
+  isReady: boolean;
 }
 
 export const GameSubmitButton = ({
@@ -16,7 +16,6 @@ export const GameSubmitButton = ({
 }: GameSubmitButtonProps) => {
   return (
     <div className="relative w-full mt-4">
-      {/* 현황 배지 */}
       <div
         className="absolute left-1/2 -translate-x-1/2 -top-7 px-6 py-2 rounded-t-xl text-white font-bold text-sm shadow-md flex items-center justify-center z-0 whitespace-nowrap"
         style={{ backgroundColor: COLORS.BADGE_PINK }}
@@ -24,22 +23,17 @@ export const GameSubmitButton = ({
         {completedCount}/{totalCount} 완료
       </div>
 
-      {/* 버튼 */}
       <button
         onClick={onComplete}
         className={cn(
-          // 보내주신 스타일 유지 (w-[110%] -left-[5%])
           'relative z-10 w-[110%] -left-[5%] h-16 rounded-full text-2xl font-extrabold shadow-lg',
           'hover:brightness-95 transition-all active:scale-95',
-          // 상태에 따른 텍스트 색상 변경
           isReady ? 'text-white' : 'bg-white text-black',
         )}
         style={{
-          // 준비 완료 상태일 때만 빨간색 배경 적용
           backgroundColor: isReady ? COLORS.TIMER_RED : undefined,
         }}
       >
-        {/* 상태에 따른 텍스트 변경 */}
         {isReady ? '취소' : UI_TEXT.BTN_COMPLETE}
       </button>
     </div>

--- a/src/features/game/ui/GameSubmitButton.tsx
+++ b/src/features/game/ui/GameSubmitButton.tsx
@@ -5,30 +5,42 @@ interface GameSubmitButtonProps {
   onComplete?: () => void;
   completedCount: number;
   totalCount: number;
+  isReady: boolean; // 상태 추가
 }
 
 export const GameSubmitButton = ({
   onComplete,
   completedCount,
   totalCount,
+  isReady,
 }: GameSubmitButtonProps) => {
   return (
     <div className="relative w-full mt-4">
+      {/* 현황 배지 */}
       <div
         className="absolute left-1/2 -translate-x-1/2 -top-7 px-6 py-2 rounded-t-xl text-white font-bold text-sm shadow-md flex items-center justify-center z-0 whitespace-nowrap"
         style={{ backgroundColor: COLORS.BADGE_PINK }}
       >
         {completedCount}/{totalCount} 완료
       </div>
+
+      {/* 버튼 */}
       <button
         onClick={onComplete}
         className={cn(
+          // 보내주신 스타일 유지 (w-[110%] -left-[5%])
           'relative z-10 w-[110%] -left-[5%] h-16 rounded-full text-2xl font-extrabold shadow-lg',
           'hover:brightness-95 transition-all active:scale-95',
-          'bg-white text-black',
+          // 상태에 따른 텍스트 색상 변경
+          isReady ? 'text-white' : 'bg-white text-black',
         )}
+        style={{
+          // 준비 완료 상태일 때만 빨간색 배경 적용
+          backgroundColor: isReady ? COLORS.TIMER_RED : undefined,
+        }}
       >
-        {UI_TEXT.BTN_COMPLETE}
+        {/* 상태에 따른 텍스트 변경 */}
+        {isReady ? '취소' : UI_TEXT.BTN_COMPLETE}
       </button>
     </div>
   );

--- a/src/features/game/ui/InventoryPanel.tsx
+++ b/src/features/game/ui/InventoryPanel.tsx
@@ -1,20 +1,19 @@
-import { ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/24/solid';
+import { ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/24/outline';
 
 import type { GameItem, InventoryUIItem } from '@/entities/game';
 import { ItemIcon } from '@/entities/game';
 import { cn } from '@/shared/lib';
-import { COLORS, UI_TEXT } from '../constants/game';
+import { COLORS } from '../constants/game';
 import { useInventory } from './useInventory';
 
 interface InventoryPanelProps {
   inventory: GameItem[] | null;
   onComplete?: () => void;
+  completedCount?: number;
+  totalCount?: number;
 }
 
-export const InventoryPanel = ({
-  inventory,
-  onComplete,
-}: InventoryPanelProps) => {
+export const InventoryPanel = ({ inventory }: InventoryPanelProps) => {
   const { visibleItems, handlePrev, handleNext, canPrev, canNext } =
     useInventory(inventory ?? []);
 
@@ -34,7 +33,7 @@ export const InventoryPanel = ({
               : 'text-white/30 cursor-not-allowed',
           )}
         >
-          <ChevronUpIcon className="w-10 h-10 stroke-2" />
+          <ChevronUpIcon className="w-10 h-10 scale-x-125 stroke-[4px]" />
         </button>
 
         <div className="flex flex-col gap-6 my-2 h-[450px]">
@@ -61,20 +60,9 @@ export const InventoryPanel = ({
               : 'text-white/30 cursor-not-allowed',
           )}
         >
-          <ChevronDownIcon className="w-10 h-10 stroke-2" />
+          <ChevronDownIcon className="w-10 h-10 scale-x-125 stroke-[4px]" />
         </button>
       </div>
-
-      <button
-        onClick={onComplete}
-        className={cn(
-          'w-full h-14 bg-white rounded-full text-xl font-extrabold shadow-lg',
-          'hover:bg-gray-100 transition-colors',
-        )}
-        style={{ color: COLORS.PRIMARY_DARK }}
-      >
-        {UI_TEXT.BTN_COMPLETE}
-      </button>
     </aside>
   );
 };

--- a/src/features/game/ui/PlayerSidebar.tsx
+++ b/src/features/game/ui/PlayerSidebar.tsx
@@ -9,7 +9,7 @@ interface PlayerSidebarProps {
 export const PlayerSidebar = ({ players }: PlayerSidebarProps) => {
   return (
     <aside
-      className="py-16 px-8 w-auto h-auto rounded-2xl flex flex-col gap-6 justify-center min-w-[120px]"
+      className="py-16 px-6 w-auto h-auto rounded-2xl flex flex-col gap-6 justify-center min-w-[120px]"
       style={{ backgroundColor: COLORS.PRIMARY_DARK }}
     >
       {players.map((player) => (
@@ -17,6 +17,7 @@ export const PlayerSidebar = ({ players }: PlayerSidebarProps) => {
           key={player.userId}
           nickname={player.nickname}
           level={player.level}
+          isConnected={player.isConnected}
         />
       ))}
     </aside>

--- a/src/mocks/game.mock.ts
+++ b/src/mocks/game.mock.ts
@@ -47,7 +47,7 @@ const MOCK_ME: Player = {
 
   status: 'IDLE',
   isConnected: true,
-  isReady: true,
+  isReady: false,
   teamId: 'BLUE',
   totalScore: 1200,
 };
@@ -140,7 +140,7 @@ export const MOCK_GAME_DRAWING: RoomState = {
     isPrivate: false,
   },
 
-  players: [MOCK_ME, MOCK_OPPONENT],
+  players: [MOCK_ME, MOCK_OPPONENT, MOCK_DISCONNECTED, MOCK_BONUS],
 
   phaseContext: {
     currentTheme: '우주비행사들의 대축제',

--- a/src/widgets/game-drawing/model/useGameSession.ts
+++ b/src/widgets/game-drawing/model/useGameSession.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react';
+
+import type { Player } from '@/entities/game';
+import { useGameDrawing } from './useGameDrawing';
+
+export interface UseGameSessionReturn {
+  players: Player[];
+  isMeReady: boolean;
+  completedCount: number;
+  totalCount: number;
+  toggleReady: () => void;
+}
+
+export const useGameSession = (): UseGameSessionReturn => {
+  const { players: initialPlayers } = useGameDrawing();
+
+  const MOCK_ID = 'id-2';
+
+  const [players, setPlayers] = useState<Player[]>(initialPlayers);
+
+  useEffect(() => {
+    if (initialPlayers && initialPlayers.length > 0) {
+      setPlayers(initialPlayers);
+    }
+  }, [initialPlayers]);
+
+  const totalCount = players.length;
+  const completedCount = players.filter((p) => p.isReady).length;
+
+  const myPlayer = players.find((p) => p.userId === MOCK_ID);
+
+  const isMeReady = myPlayer?.isReady ?? false;
+
+  const toggleReady = () => {
+    setPlayers((prevPlayers) =>
+      prevPlayers.map((p) =>
+        p.userId === MOCK_ID ? { ...p, isReady: !p.isReady } : p,
+      ),
+    );
+  };
+
+  return {
+    players,
+    isMeReady,
+    completedCount,
+    totalCount,
+    toggleReady,
+  };
+};

--- a/src/widgets/game-drawing/model/useGameSubmission.ts
+++ b/src/widgets/game-drawing/model/useGameSubmission.ts
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import type { Player } from '@/entities/game';
 import { useGameDrawing } from './useGameDrawing';
 
-export interface UseGameSessionReturn {
+interface GameSubmissionState {
   players: Player[];
   isMeReady: boolean;
   completedCount: number;
@@ -11,7 +11,7 @@ export interface UseGameSessionReturn {
   toggleReady: () => void;
 }
 
-export const useGameSession = (): UseGameSessionReturn => {
+export const useGameSubmission = (): GameSubmissionState => {
   const { players: initialPlayers } = useGameDrawing();
 
   const MOCK_ID = 'id-2';

--- a/src/widgets/game-drawing/ui/GameWidget.tsx
+++ b/src/widgets/game-drawing/ui/GameWidget.tsx
@@ -1,6 +1,7 @@
 import {
   GameCanvas,
   GameHeader,
+  GameSubmitButton,
   InventoryPanel,
   PlayerSidebar,
 } from '@/features/game';
@@ -8,6 +9,10 @@ import { useGameDrawing } from '../model/useGameDrawing';
 
 const GameWidget = () => {
   const { players, inventory, endsAt, currentTheme } = useGameDrawing();
+
+  const completedCount = 3;
+  const totalCount = 6;
+  const handleComplete = () => console.log('제출');
 
   return (
     <div className="w-full h-screen flex justify-between items-center font-ssrm px-20 py-4 overflow-hidden gap-16">
@@ -18,7 +23,15 @@ const GameWidget = () => {
         <GameCanvas />
       </main>
 
-      <InventoryPanel inventory={inventory} />
+      <aside className="h-full flex flex-col justify-center gap-y-20">
+        <InventoryPanel inventory={inventory} />
+
+        <GameSubmitButton
+          onComplete={handleComplete}
+          completedCount={completedCount}
+          totalCount={totalCount}
+        />
+      </aside>
     </div>
   );
 };

--- a/src/widgets/game-drawing/ui/GameWidget.tsx
+++ b/src/widgets/game-drawing/ui/GameWidget.tsx
@@ -6,13 +6,13 @@ import {
   PlayerSidebar,
 } from '@/features/game';
 import { useGameDrawing } from '../model/useGameDrawing';
-import { useGameSession } from '../model/useGameSession';
+import { useGameSubmission } from '../model/useGameSubmission';
 
 const GameWidget = () => {
   const { inventory, endsAt, currentTheme } = useGameDrawing();
 
   const { players, completedCount, totalCount, isMeReady, toggleReady } =
-    useGameSession();
+    useGameSubmission();
 
   return (
     <div className="w-full h-screen flex justify-between items-center font-ssrm px-20 py-4 overflow-hidden gap-16">

--- a/src/widgets/game-drawing/ui/GameWidget.tsx
+++ b/src/widgets/game-drawing/ui/GameWidget.tsx
@@ -6,13 +6,13 @@ import {
   PlayerSidebar,
 } from '@/features/game';
 import { useGameDrawing } from '../model/useGameDrawing';
+import { useGameSession } from '../model/useGameSession';
 
 const GameWidget = () => {
-  const { players, inventory, endsAt, currentTheme } = useGameDrawing();
+  const { inventory, endsAt, currentTheme } = useGameDrawing();
 
-  const completedCount = 3;
-  const totalCount = 6;
-  const handleComplete = () => console.log('제출');
+  const { players, completedCount, totalCount, isMeReady, toggleReady } =
+    useGameSession();
 
   return (
     <div className="w-full h-screen flex justify-between items-center font-ssrm px-20 py-4 overflow-hidden gap-16">
@@ -27,9 +27,10 @@ const GameWidget = () => {
         <InventoryPanel inventory={inventory} />
 
         <GameSubmitButton
-          onComplete={handleComplete}
+          onComplete={toggleReady}
           completedCount={completedCount}
           totalCount={totalCount}
+          isReady={isMeReady}
         />
       </aside>
     </div>


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- 간단한 퍼블리싱과 구현 작업을 진행했습니다😄
- `useGameSession.ts` 훅을 새롭게 작성했습니다. 리뷰 부탁드립니다!

## ✨ 변경 사항 (Changes)

- 남은 시간(1/3, 2/3, 그 외)에 따라 시계 UI(`GameHeader`에 작성됨)의 색상 변경(빨강, 노랑, 초록)
- `PlayerAvatar`, `ItemIcon`, `marquee`에 그림자 적용
- `InventoryPanel`로부터 준비 버튼 분리 및 Mock 데이터 기반 준비 상태 구현 (`useGameSession.ts`)
- 아이템을 타 플레이어에게 드래그 앤 드롭하여 사용하는 기능은, 이후에 진행하도록 하겠습니다! (#51)

## 📸 스크린샷 (Screenshots)

<img width="1822" height="1106" alt="image" src="https://github.com/user-attachments/assets/5ab26021-66cb-4665-9774-d562309f4250" />
<img width="1822" height="1106" alt="image" src="https://github.com/user-attachments/assets/8cb9ede1-b147-4ea9-bb30-80a95bcc1760" />

## ✅ 리뷰어 체크리스트 (Reviewer Checklist)

- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?

## 📢 참고 사항 (Notes)

- 생략하겠습니다!

## 🧐 이슈 (Related Issues)

- Closes #58 
