### PR TITLE
feat: (#35) OAuth를 통한 카카오, 구글 로그인 기능 구현

### DIFF
--- a/src/app/Router.tsx
+++ b/src/app/Router.tsx
@@ -6,6 +6,7 @@ import { Spinner } from '@/shared/ui/Spinner';
 import PrivateRoute from './PrivateRoute';
 
 const LoginPage = lazy(() => import('@/pages/LoginPage'));
+const LoginCallbackPage = lazy(() => import('@/pages/LoginCallbackPage'));
 const SignupPage = lazy(() => import('@/pages/SignupPage'));
 const WelcomePage = lazy(() => import('@/pages/WelcomePage'));
 const MainPage = lazy(() => import('@/pages/MainPage'));
@@ -25,6 +26,10 @@ const router = createBrowserRouter([
       {
         path: '/login',
         element: <LoginPage />,
+      },
+      {
+        path: '/auth/callback',
+        element: <LoginCallbackPage />,
       },
       {
         path: '/signup',

--- a/src/app/config/setupAxios.ts
+++ b/src/app/config/setupAxios.ts
@@ -1,0 +1,61 @@
+import type { AxiosError } from 'axios';
+
+import { useAuthStore } from '@/entities/user';
+import { postRefreshToken } from '@/features/auth';
+import { instance } from '@/shared/api';
+import { parseAccessToken } from '@/shared/lib';
+
+export const setupAxiosInterceptors = () => {
+  instance.interceptors.request.use((config) => {
+    const token = useAuthStore.getState().accessToken;
+    const isAuthPath =
+      config.url?.includes('auth/login') || config.url?.includes('auth/signup');
+    const cleanToken = token ? token.replace(/"/g, '') : null;
+
+    if (cleanToken && !isAuthPath) {
+      config.headers.Authorization = `Bearer ${cleanToken}`;
+    }
+    return config;
+  });
+
+  instance.interceptors.response.use(
+    (res) => res,
+    async (error: AxiosError) => {
+      const originalRequest = error.config as any; // 타입 편의상 any 사용 혹은 확장 타입 사용
+      const isAuthPath =
+        originalRequest.url?.includes('auth/login') ||
+        originalRequest.url?.includes('auth/signup');
+
+      if (
+        error.response?.status === 401 &&
+        !originalRequest._retry &&
+        !isAuthPath
+      ) {
+        originalRequest._retry = true;
+
+        try {
+          const res = await postRefreshToken();
+          if (!res.success) throw new Error('토큰 갱신 실패');
+
+          const newAccessToken = res.data.content;
+          const decoded = parseAccessToken(newAccessToken);
+
+          useAuthStore.getState().setAuth({
+            user: { id: decoded.sub, nickname: decoded.nickname },
+            accessToken: newAccessToken,
+          });
+
+          const cleanNewToken = newAccessToken.replace(/"/g, '');
+          originalRequest.headers.Authorization = `Bearer ${cleanNewToken}`;
+
+          return instance(originalRequest);
+        } catch (err) {
+          useAuthStore.getState().clearAuth();
+          window.location.href = '/login';
+          return Promise.reject(err);
+        }
+      }
+      return Promise.reject(error);
+    },
+  );
+};

--- a/src/app/main.tsx
+++ b/src/app/main.tsx
@@ -2,7 +2,10 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 
 import App from './App';
+import { setupAxiosInterceptors } from './config/setupAxios';
 import './global.css';
+
+setupAxiosInterceptors();
 
 export const enableMSW = async () => {
   if (import.meta.env.DEV && import.meta.env.VITE_USE_MSW) {

--- a/src/features/auth/index.ts
+++ b/src/features/auth/index.ts
@@ -2,6 +2,7 @@ export { postLogin } from './api/postLogin';
 export { postRefreshToken } from './api/postRefreshToken';
 export { postSignup } from './api/postSignup';
 export * from './model/types';
+export { useLoginCallback } from './model/useLoginCallback';
 export { authQueries } from './queries/authQueries';
 export { LoginForm } from './ui/LoginForm';
 export { SignupForm } from './ui/SignupForm';

--- a/src/features/auth/lib/auth.ts
+++ b/src/features/auth/lib/auth.ts
@@ -1,0 +1,7 @@
+export const navigateToSocialLogin = (provider: 'google' | 'kakao') => {
+  const baseUrl = import.meta.env.VITE_SOCIAL_LOGIN_URL;
+  const currentDomain = window.location.origin;
+  const targetUrl = `${currentDomain}/auth/callback`;
+
+  window.location.href = `${baseUrl}/auth/${provider}?state=${encodeURIComponent(targetUrl)}`;
+};

--- a/src/features/auth/model/useLogin.ts
+++ b/src/features/auth/model/useLogin.ts
@@ -15,6 +15,7 @@ import { authQueries } from '../queries/authQueries';
 export const useLogin = () => {
   const navigate = useNavigate();
   const setAuth = useAuthStore((state) => state.setAuth);
+
   const [isAnyFieldFocused, setIsAnyFieldFocused] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -38,8 +39,6 @@ export const useLogin = () => {
         return;
       }
 
-      localStorage.setItem('accessToken', result.accessToken);
-
       const decoded = parseAccessToken(result.accessToken);
 
       setAuth({
@@ -53,12 +52,13 @@ export const useLogin = () => {
       setErrorMessage(null);
       navigate('/welcome');
     },
+
     onError: (err: AxiosError<LoginFailureResponse>) => {
       setErrorMessage(err.response?.data?.message ?? '로그인에 실패했습니다.');
     },
   });
 
-  const onSubmit = (form: { username: string; password: string }) => {
+  const onSubmit = (form: LoginFormValues) => {
     login(form);
   };
 

--- a/src/features/auth/model/useLoginCallback.ts
+++ b/src/features/auth/model/useLoginCallback.ts
@@ -1,0 +1,51 @@
+import { useEffect, useRef } from 'react';
+import { useNavigate } from 'react-router';
+import { useMutation } from '@tanstack/react-query';
+
+import { useAuthStore } from '@/entities/user';
+import { parseAccessToken } from '@/shared/lib';
+import { authQueries } from '../queries/authQueries';
+
+export const useLoginCallback = () => {
+  const navigate = useNavigate();
+  const setAuth = useAuthStore((state) => state.setAuth);
+
+  const isRun = useRef(false);
+
+  const { mutateAsync: refreshMutate } = useMutation(authQueries.refresh());
+
+  useEffect(() => {
+    if (isRun.current) return;
+    isRun.current = true;
+
+    const processLogin = async () => {
+      try {
+        const response = await refreshMutate();
+        const { accessToken } = response;
+
+        if (!accessToken) {
+          throw new Error('토큰이 발급되지 않았습니다.');
+        }
+
+        const decoded = parseAccessToken(accessToken);
+
+        setAuth({
+          user: {
+            id: decoded.sub,
+            nickname: decoded.nickname,
+          },
+          accessToken: accessToken,
+        });
+
+        navigate('/welcome', { replace: true });
+      } catch (error) {
+        console.error('자동 로그인(리프레시) 실패:', error);
+
+        alert('로그인 정보를 불러오는데 실패했습니다. 다시 로그인해주세요.');
+        navigate('/login', { replace: true });
+      }
+    };
+
+    processLogin();
+  }, [navigate, setAuth, refreshMutate]);
+};

--- a/src/features/auth/model/useLoginCallback.ts
+++ b/src/features/auth/model/useLoginCallback.ts
@@ -39,8 +39,6 @@ export const useLoginCallback = () => {
 
         navigate('/welcome', { replace: true });
       } catch (error) {
-        console.error('자동 로그인(리프레시) 실패:', error);
-
         alert('로그인 정보를 불러오는데 실패했습니다. 다시 로그인해주세요.');
         navigate('/login', { replace: true });
       }

--- a/src/features/auth/model/useSignup.ts
+++ b/src/features/auth/model/useSignup.ts
@@ -69,9 +69,6 @@ export const useSignup = () => {
         setErrorMessage(null);
         navigate('/welcome');
       } catch (err: unknown) {
-        if (err instanceof AxiosError) {
-          console.error('자동 로그인 실패:', err.response?.data?.message);
-        }
         alert('회원가입에 성공했어요! 로그인 페이지로 이동합니다.');
         navigate('/login');
       }

--- a/src/features/auth/queries/authQueries.ts
+++ b/src/features/auth/queries/authQueries.ts
@@ -1,6 +1,7 @@
 import { mutationOptions } from '@tanstack/react-query';
 
 import { postLogin } from '../api/postLogin';
+import { postRefreshToken } from '../api/postRefreshToken';
 import { postSignup } from '../api/postSignup';
 
 export const authQueries = {
@@ -16,5 +17,11 @@ export const authQueries = {
     mutationOptions({
       mutationKey: [...authQueries.auth(), 'signup'] as const,
       mutationFn: postSignup,
+    }),
+
+  refresh: () =>
+    mutationOptions({
+      mutationKey: [...authQueries.auth(), 'refresh'] as const,
+      mutationFn: postRefreshToken,
     }),
 };

--- a/src/features/auth/ui/GoogleLoginButton.tsx
+++ b/src/features/auth/ui/GoogleLoginButton.tsx
@@ -4,7 +4,10 @@ import { Button } from '@/shared/ui/Button';
 export const GoogleLoginButton = () => {
   const handleLogin = () => {
     const baseUrl = import.meta.env.VITE_SOCIAL_LOGIN_URL;
-    window.location.href = `${baseUrl}/auth/google`;
+    const currentDomain = window.location.origin;
+    const targetUrl = `${currentDomain}/auth/callback`;
+
+    window.location.href = `${baseUrl}/auth/google?state=${encodeURIComponent(targetUrl)}`;
   };
 
   return (

--- a/src/features/auth/ui/GoogleLoginButton.tsx
+++ b/src/features/auth/ui/GoogleLoginButton.tsx
@@ -1,13 +1,10 @@
-import { useNavigate } from 'react-router';
-
 import googleIcon from '@/assets/google.svg';
 import { Button } from '@/shared/ui/Button';
 
 export const GoogleLoginButton = () => {
-  const navigate = useNavigate();
-
   const handleLogin = () => {
-    navigate('/welcome');
+    const baseUrl = import.meta.env.VITE_SOCIAL_LOGIN_URL;
+    window.location.href = `${baseUrl}/auth/google`;
   };
 
   return (

--- a/src/features/auth/ui/GoogleLoginButton.tsx
+++ b/src/features/auth/ui/GoogleLoginButton.tsx
@@ -1,20 +1,13 @@
 import googleIcon from '@/assets/google.svg';
 import { Button } from '@/shared/ui/Button';
+import { navigateToSocialLogin } from '../lib/auth';
 
 export const GoogleLoginButton = () => {
-  const handleLogin = () => {
-    const baseUrl = import.meta.env.VITE_SOCIAL_LOGIN_URL;
-    const currentDomain = window.location.origin;
-    const targetUrl = `${currentDomain}/auth/callback`;
-
-    window.location.href = `${baseUrl}/auth/google?state=${encodeURIComponent(targetUrl)}`;
-  };
-
   return (
     <Button
       variant="google"
       className="w-full justify-between hover:underline"
-      onClick={handleLogin}
+      onClick={() => navigateToSocialLogin('google')}
     >
       <img src={googleIcon} className="w-6" alt="구글" />
       <p className="text-lg">Google 로그인</p>

--- a/src/features/auth/ui/KakaoLoginButton.tsx
+++ b/src/features/auth/ui/KakaoLoginButton.tsx
@@ -4,7 +4,10 @@ import { Button } from '@/shared/ui/Button';
 export const KakaoLoginButton = () => {
   const handleLogin = () => {
     const baseUrl = import.meta.env.VITE_SOCIAL_LOGIN_URL;
-    window.location.href = `${baseUrl}/auth/kakao`;
+    const currentDomain = window.location.origin;
+    const targetUrl = `${currentDomain}/auth/callback`;
+
+    window.location.href = `${baseUrl}/auth/kakao?state=${encodeURIComponent(targetUrl)}`;
   };
 
   return (

--- a/src/features/auth/ui/KakaoLoginButton.tsx
+++ b/src/features/auth/ui/KakaoLoginButton.tsx
@@ -1,13 +1,10 @@
-import { useNavigate } from 'react-router';
-
 import kakaoIcon from '@/assets/kakao.svg';
 import { Button } from '@/shared/ui/Button';
 
 export const KakaoLoginButton = () => {
-  const navigate = useNavigate();
-
   const handleLogin = () => {
-    navigate('/welcome');
+    const baseUrl = import.meta.env.VITE_SOCIAL_LOGIN_URL;
+    window.location.href = `${baseUrl}/auth/kakao`;
   };
 
   return (

--- a/src/features/auth/ui/KakaoLoginButton.tsx
+++ b/src/features/auth/ui/KakaoLoginButton.tsx
@@ -1,20 +1,13 @@
 import kakaoIcon from '@/assets/kakao.svg';
 import { Button } from '@/shared/ui/Button';
+import { navigateToSocialLogin } from '../lib/auth';
 
 export const KakaoLoginButton = () => {
-  const handleLogin = () => {
-    const baseUrl = import.meta.env.VITE_SOCIAL_LOGIN_URL;
-    const currentDomain = window.location.origin;
-    const targetUrl = `${currentDomain}/auth/callback`;
-
-    window.location.href = `${baseUrl}/auth/kakao?state=${encodeURIComponent(targetUrl)}`;
-  };
-
   return (
     <Button
       variant="kakao"
       className="w-full justify-between hover:underline"
-      onClick={handleLogin}
+      onClick={() => navigateToSocialLogin('kakao')}
     >
       <img src={kakaoIcon} className="w-6" alt="카카오" />
       <p className="text-lg">카카오 로그인</p>

--- a/src/pages/LoginCallbackPage.tsx
+++ b/src/pages/LoginCallbackPage.tsx
@@ -1,25 +1,36 @@
-import { useEffect } from 'react';
-import { useNavigate, useSearchParams } from 'react-router';
+import { useEffect, useRef } from 'react';
+import { useNavigate } from 'react-router';
 
 import { useAuthStore } from '@/entities/user';
+import { instance } from '@/shared/api/axios';
 import { parseAccessToken } from '@/shared/lib';
 import { Spinner } from '@/shared/ui/Spinner';
 
 const LoginCallbackPage = () => {
-  const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const setAuth = useAuthStore((state) => state.setAuth);
 
-  useEffect(() => {
-    const accessToken = searchParams.get('accessToken');
+  const isRun = useRef(false);
 
-    if (accessToken) {
+  useEffect(() => {
+    if (isRun.current) return;
+    isRun.current = true;
+
+    const loginProcess = async () => {
       try {
+        const response = await instance.post('/auth/refresh');
+
+        const { accessToken } = response.data;
+
+        if (!accessToken) throw new Error('토큰 없음');
+
+        localStorage.setItem('accessToken', accessToken);
+
         const decoded = parseAccessToken(accessToken);
 
         setAuth({
           user: {
-            id: decoded.sub,
+            id: decoded.sub || decoded.id,
             nickname: decoded.nickname,
           },
           accessToken: accessToken,
@@ -27,18 +38,16 @@ const LoginCallbackPage = () => {
 
         navigate('/welcome', { replace: true });
       } catch (error) {
-        alert('로그인 정보가 올바르지 않습니다.');
+        console.error('로그인 실패:', error);
+        alert('소셜 로그인 처리에 실패했습니다.');
         navigate('/login', { replace: true });
       }
-    } else {
-      alert('소셜 로그인 처리에 실패했습니다.');
-      navigate('/login', { replace: true });
-    }
-  }, [searchParams, navigate, setAuth]);
+    };
 
-  return (
-    <Spinner fixed transparent size="xl" message="소셜 로그인 중입니다..." />
-  );
+    loginProcess();
+  }, [navigate, setAuth]);
+
+  return <Spinner fixed transparent size="xl" message="로그인 확인 중..." />;
 };
 
 export default LoginCallbackPage;

--- a/src/pages/LoginCallbackPage.tsx
+++ b/src/pages/LoginCallbackPage.tsx
@@ -1,51 +1,8 @@
-import { useEffect, useRef } from 'react';
-import { useNavigate } from 'react-router';
-
-import { useAuthStore } from '@/entities/user';
-import { instance } from '@/shared/api/axios';
-import { parseAccessToken } from '@/shared/lib';
+import { useLoginCallback } from '@/features/auth';
 import { Spinner } from '@/shared/ui/Spinner';
 
 const LoginCallbackPage = () => {
-  const navigate = useNavigate();
-  const setAuth = useAuthStore((state) => state.setAuth);
-
-  const isRun = useRef(false);
-
-  useEffect(() => {
-    if (isRun.current) return;
-    isRun.current = true;
-
-    const loginProcess = async () => {
-      try {
-        const response = await instance.post('/auth/refresh');
-
-        const { accessToken } = response.data;
-
-        if (!accessToken) throw new Error('토큰 없음');
-
-        localStorage.setItem('accessToken', accessToken);
-
-        const decoded = parseAccessToken(accessToken);
-
-        setAuth({
-          user: {
-            id: decoded.sub || decoded.id,
-            nickname: decoded.nickname,
-          },
-          accessToken: accessToken,
-        });
-
-        navigate('/welcome', { replace: true });
-      } catch (error) {
-        console.error('로그인 실패:', error);
-        alert('소셜 로그인 처리에 실패했습니다.');
-        navigate('/login', { replace: true });
-      }
-    };
-
-    loginProcess();
-  }, [navigate, setAuth]);
+  useLoginCallback();
 
   return <Spinner fixed transparent size="xl" message="로그인 확인 중..." />;
 };

--- a/src/pages/LoginCallbackPage.tsx
+++ b/src/pages/LoginCallbackPage.tsx
@@ -1,0 +1,44 @@
+import { useEffect } from 'react';
+import { useNavigate, useSearchParams } from 'react-router';
+
+import { useAuthStore } from '@/entities/user';
+import { parseAccessToken } from '@/shared/lib';
+import { Spinner } from '@/shared/ui/Spinner';
+
+const LoginCallbackPage = () => {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const setAuth = useAuthStore((state) => state.setAuth);
+
+  useEffect(() => {
+    const accessToken = searchParams.get('accessToken');
+
+    if (accessToken) {
+      try {
+        const decoded = parseAccessToken(accessToken);
+
+        setAuth({
+          user: {
+            id: decoded.sub,
+            nickname: decoded.nickname,
+          },
+          accessToken: accessToken,
+        });
+
+        navigate('/welcome', { replace: true });
+      } catch (error) {
+        alert('로그인 정보가 올바르지 않습니다.');
+        navigate('/login', { replace: true });
+      }
+    } else {
+      alert('소셜 로그인 처리에 실패했습니다.');
+      navigate('/login', { replace: true });
+    }
+  }, [searchParams, navigate, setAuth]);
+
+  return (
+    <Spinner fixed transparent size="xl" message="소셜 로그인 중입니다..." />
+  );
+};
+
+export default LoginCallbackPage;

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -13,13 +13,13 @@ import {
 
 const MainPage = () => {
   const navigate = useNavigate();
-  const { clearAuth } = useAuthStore();
+  const { user, clearAuth } = useAuthStore();
   const { searchQuery, setSearchQuery, setCommitSearch } = useSearchStore();
 
   const { open: openCreateRoomModal } = useCreateRoomModalStore();
 
   const currentLv = 1;
-  const nickname = '밥아저씨';
+  const nickname = user!.nickname;
   const currentXp = 30;
   const maxXp = 50;
 

--- a/src/pages/WelcomePage.tsx
+++ b/src/pages/WelcomePage.tsx
@@ -6,27 +6,28 @@ import { useAuthStore } from '@/entities/user';
 
 const WelcomePage = () => {
   const navigate = useNavigate();
+
   const user = useAuthStore((state) => state.user);
   const [leaving, setLeaving] = useState(false);
 
   useEffect(() => {
     if (!user) {
-      navigate('/login');
+      navigate('/login', { replace: true });
     }
   }, [user, navigate]);
 
   useEffect(() => {
+    if (!user) return;
+
     const timer = setTimeout(() => {
       setLeaving(true);
-      setTimeout(() => navigate('/'), 500);
-    }, 3000);
+      setTimeout(() => navigate('/', { replace: true }), 500);
+    }, 2000);
 
     return () => clearTimeout(timer);
-  }, [navigate]);
+  }, [user, navigate]);
 
-  const goToLoginPage = () => {
-    navigate('/login');
-  };
+  if (!user) return null;
 
   return (
     <div className="flex flex-col items-center justify-center h-screen">
@@ -38,12 +39,11 @@ const WelcomePage = () => {
           ease: 'easeInOut',
           scale: { type: 'spring', bounce: 0.4 },
         }}
-        onClick={goToLoginPage}
-        className="w-[250px] h-[250px] bg-white rounded-full shadow-md cursor-pointer"
+        className="w-[250px] h-[250px] bg-white rounded-full shadow-md"
       />
 
       <div className="mt-10 text-center font-ssrm font-bold">
-        <span className="text-4xl text-green-500">{user?.nickname}</span>
+        <span className="text-4xl text-green-500">{user.nickname}</span>
         <span className="text-4xl">
           님<br />
         </span>

--- a/src/shared/api/axios.ts
+++ b/src/shared/api/axios.ts
@@ -62,7 +62,6 @@ instance.interceptors.response.use(
         const res = await postRefreshToken();
 
         if (!res.success) {
-          console.error(res.data.message);
           return Promise.reject(new Error('토큰 갱신 실패'));
         }
 
@@ -75,8 +74,6 @@ instance.interceptors.response.use(
 
         return instance(originalRequest);
       } catch (err) {
-        console.error('리프레시 실패');
-
         localStorage.clear();
 
         window.location.href = '/login';

--- a/src/shared/api/axios.ts
+++ b/src/shared/api/axios.ts
@@ -1,21 +1,6 @@
-import type { AxiosError, AxiosRequestConfig } from 'axios';
+import type { AxiosRequestConfig } from 'axios';
 import axios from 'axios';
 import queryString from 'query-string';
-
-import { postRefreshToken } from '@/features/auth';
-
-interface APIRequest extends Omit<AxiosRequestConfig, 'data' | 'method'> {
-  url: string;
-  params?: Record<string, any>;
-}
-
-interface APIRequestWithData<D = any> extends APIRequest {
-  data?: D;
-}
-
-interface RetryConfig extends AxiosRequestConfig {
-  _retry?: boolean;
-}
 
 const paramsSerializer = (params: Record<string, any>) =>
   queryString.stringify(params, { skipEmptyString: true, skipNull: true });
@@ -26,65 +11,6 @@ const common: AxiosRequestConfig = {
   paramsSerializer,
 };
 
-const instance = axios.create(common);
+export const instance = axios.create(common);
 
-instance.interceptors.request.use((config) => {
-  const token = localStorage.getItem('accessToken');
-
-  const isAuthPath =
-    config.url?.includes('auth/login') || config.url?.includes('auth/signup');
-
-  const cleanToken = token ? token.replace(/"/g, '') : null;
-
-  if (cleanToken && !isAuthPath)
-    config.headers.Authorization = `Bearer ${cleanToken}`;
-
-  return config;
-});
-
-instance.interceptors.response.use(
-  (res) => res,
-  async (error: AxiosError) => {
-    const originalRequest = error.config as RetryConfig;
-
-    const isAuthPath =
-      originalRequest.url?.includes('auth/login') ||
-      originalRequest.url?.includes('auth/signup');
-
-    if (
-      error.response?.status === 401 &&
-      !originalRequest._retry &&
-      !isAuthPath
-    ) {
-      originalRequest._retry = true;
-
-      try {
-        const res = await postRefreshToken();
-
-        if (!res.success) {
-          return Promise.reject(new Error('토큰 갱신 실패'));
-        }
-
-        const newAccessToken = res.data.content;
-        localStorage.setItem('accessToken', newAccessToken);
-
-        if (!originalRequest.headers) originalRequest.headers = {};
-        const cleanNewToken = newAccessToken.replace(/"/g, '');
-        originalRequest.headers.Authorization = `Bearer ${cleanNewToken}`;
-
-        return instance(originalRequest);
-      } catch (err) {
-        localStorage.clear();
-
-        window.location.href = '/login';
-
-        return Promise.reject(err);
-      }
-    }
-
-    return Promise.reject(error);
-  },
-);
-
-export { instance };
-export type { APIRequest, APIRequestWithData };
+export type { AxiosError, AxiosRequestConfig } from 'axios';

--- a/src/shared/ui/Spinner/Spinner.utils.ts
+++ b/src/shared/ui/Spinner/Spinner.utils.ts
@@ -8,9 +8,9 @@ const SPINNER_SIZES = {
 type SpinnerSize = keyof typeof SPINNER_SIZES;
 
 export interface SpinnerStyleProps {
-  fixed: boolean;
-  overlay: boolean;
-  transparent: boolean;
+  fixed?: boolean;
+  overlay?: boolean;
+  transparent?: boolean;
   size: SpinnerSize;
 }
 


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- 소셜 로그인(OAuth) 인증 처리를 위한 콜백 페이지 로직(`useLoginCallback`)을 구현했습니다.
- 기존 로그인/회원가입 로직에서 `localStorage`에 직접 접근하던 코드를 제거하고, Zustand Store(`persist`)를 통한 상태 관리로 일원화했습니다.
- `LoginCallbackPage`의 비즈니스 로직을 훅으로 분리하여 Page(UI)와 Feature(Logic)의 역할을 명확히 분리했습니다.
- (⭐️) 기존 Shared 레이어(`axios.ts`)에서 상위 레이어(`Features`, `Entities`)를 참조하여 발생하던 순환 참조 위험을 제거했습니다. Axios 인스턴스 생성과 인터셉터 설정 로직을 분리하여, App 레이어에서 인터셉터를 주입하는 방식으로 구조를 변경했습니다.
- 순환 참조 방지를 위해 `Axios` 인터셉터 설정을 `App` 레이어로 분리한 부분과, 로컬 스토리지 직접 접근을 제거하고 상태 관리를 일원화한 로직 위주로 봐주시면 감사하겠습니다!

## ✨ 변경 사항 (Changes)

- `src/features/auth/model/useLoginCallback.ts`: 소셜 로그인 인가 코드 처리 및 토큰 발급 로직을 담당하는 커스텀 훅 추가.
- `src/pages/LoginCallbackPage.tsx`: 복잡한 로직을 제거하고 useLoginCallback 훅을 호출하도록 단순화.
- `src/features/auth/model/useLogin.ts`: localStorage.setItem을 삭제하고 setAuth만 사용하도록 리팩토링.
- `src/features/auth/queries/authQueries.ts`: 리프레시 토큰 및 인증 관련 쿼리 옵션 구조 개선.
- 기타: 카카오/구글 로그인 버튼 및 라우터 설정 소폭 수정.
- (⭐️) `src/app/config/setupAxios.ts`: Shared, Entities, Features를 조합하여 Axios 인터셉터를 설정하는 로직을 이곳으로 이동했습니다.
- `src/shared/api/axios.ts`: 상위 레이어 의존성을 모두 제거하고, 순수한 Axios 인스턴스만 생성하도록 변경했습니다.
- `src/app/main.tsx`: 앱 초기화 시점에 setupAxiosInterceptors()를 실행하도록 설정했습니다.

## 📸 스크린샷 (Screenshots)

<img width="1822" height="1106" alt="image" src="https://github.com/user-attachments/assets/8df57b6d-a9e0-4992-a07f-b795bef49b83" />

## ✅ 리뷰어 체크리스트 (Reviewer Checklist)

- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?

## 📢 참고 사항 (Notes)

- 참고 사항 기재

## 🧐 이슈 (Related Issues)

- Closes #35
