### PR TITLE
feat: (#89) 게임 그리기 툴팁과 되돌리기 버튼, 마우스 포인터 추가

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -39,6 +39,9 @@ export default tseslint.config(
       ...tseslint.configs.recommended[0].rules,
       ...react.configs.recommended.rules,
 
+      'no-unused-vars': 'off',
+      '@typescript-eslint/no-unused-vars': 'warn',
+
       'react-hooks/rules-of-hooks': 'error',
       'react-hooks/exhaustive-deps': 'warn',
 

--- a/src/features/drawing/model/useDrawing.ts
+++ b/src/features/drawing/model/useDrawing.ts
@@ -22,21 +22,23 @@ export const useDrawing = ({ tool, color, size }: UseDrawingProps) => {
   const undo = useCallback(() => {
     if (lines.length === 0 || isDrawingRef.current) return;
 
-    setLines((prev) => {
-      const lastLine = prev[prev.length - 1];
-      setRedoStack((prevStack) => [...prevStack, lastLine]);
-      return prev.slice(0, -1);
-    });
+    // 마지막 선을 가져와서 Redo 스택에 추가
+    const lastLine = lines[lines.length - 1];
+    setRedoStack((prev) => [...prev, lastLine]);
+
+    // Lines 스택에서 마지막 선 제거
+    setLines((prev) => prev.slice(0, -1));
   }, [lines]);
 
   const redo = useCallback(() => {
     if (redoStack.length === 0 || isDrawingRef.current) return;
 
-    setRedoStack((prev) => {
-      const lineToRestore = prev[prev.length - 1];
-      setLines((prevLines) => [...prevLines, lineToRestore]);
-      return prev.slice(0, -1);
-    });
+    // Redo 스택의 마지막 요소를 다시 복구
+    const lineToRestore = redoStack[redoStack.length - 1];
+    setLines((prev) => [...prev, lineToRestore]);
+
+    // Redo 스택에서 제거
+    setRedoStack((prev) => prev.slice(0, -1));
   }, [redoStack]);
 
   useEffect(() => {

--- a/src/features/drawing/ui/GameCanvas.tsx
+++ b/src/features/drawing/ui/GameCanvas.tsx
@@ -1,30 +1,30 @@
 import type { ComponentRef } from 'react';
-import { useRef } from 'react';
-import { Layer, Line, Stage } from 'react-konva';
+import { useRef, useState } from 'react';
+import { Circle, Layer, Line, Stage } from 'react-konva';
+import type { KonvaEventObject } from 'konva/lib/Node';
 
 import { Mannequin } from '@/assets';
-import type { DrawingTool } from '../model/types';
+import type { DrawingTool, DrawLine } from '../model/types';
 import { useCanvasSize } from '../model/useCanvasSize';
 import { useTextureLoader } from '../model/useTextureLoader';
 import { BucketResult } from './BucketResult';
 import { CanvasBackground } from './CanvasBackground';
 import { TextureBrushLine } from './TextureBrushLine';
 
+type KonvaHandler = (event: KonvaEventObject<MouseEvent | TouchEvent>) => void;
+
 interface GameCanvasProps {
   activeTool: DrawingTool;
   strokeWidth: number;
-  selectedColor: string;
-  lines: any[];
-  onMouseDown: (e: any) => void;
-  onMouseMove: (e: any) => void;
+  lines: DrawLine[];
+  onMouseDown: KonvaHandler;
+  onMouseMove: KonvaHandler;
   onMouseUp: () => void;
 }
 
 export const GameCanvas = ({
-  // TODO: activeTool, strokeWidth, selectedColor 사용 로직 추후 구현
   activeTool,
   strokeWidth,
-  selectedColor,
   lines,
   onMouseDown,
   onMouseMove,
@@ -34,7 +34,21 @@ export const GameCanvas = ({
   const size = useCanvasSize(containerRef);
   const { textures } = useTextureLoader();
 
+  const [cursorPos, setCursorPos] = useState({ x: 0, y: 0 });
+  const [isHovering, setIsHovering] = useState(false);
+
   const isCanvasReady = size.width > 0 && size.height > 0;
+
+  const handleMouseMoveInternal: KonvaHandler = (event) => {
+    const stage = event.target.getStage();
+    const position = stage?.getPointerPosition();
+
+    if (position) {
+      setCursorPos({ x: position.x, y: position.y });
+    }
+
+    onMouseMove(event);
+  };
 
   return (
     <div
@@ -48,11 +62,15 @@ export const GameCanvas = ({
             width={size.width}
             height={size.height}
             onMouseDown={onMouseDown}
-            onMouseMove={onMouseMove}
+            onMouseMove={handleMouseMoveInternal}
             onMouseUp={onMouseUp}
-            onMouseLeave={onMouseUp}
+            onMouseEnter={() => setIsHovering(true)}
+            onMouseLeave={() => {
+              setIsHovering(false);
+              onMouseUp();
+            }}
             onTouchStart={onMouseDown}
-            onTouchMove={onMouseMove}
+            onTouchMove={handleMouseMoveInternal}
             onTouchEnd={onMouseUp}
           >
             <Layer>
@@ -118,6 +136,22 @@ export const GameCanvas = ({
                   />
                 );
               })}
+            </Layer>
+
+            {/* 브러시 크기에 따른 마우스 포인터 */}
+            <Layer>
+              {isHovering && activeTool !== 'bucket' && (
+                <Circle
+                  x={cursorPos.x}
+                  y={cursorPos.y}
+                  radius={strokeWidth / 16}
+                  fill={activeTool === 'eraser' ? 'white' : undefined}
+                  stroke="gray"
+                  strokeWidth={1}
+                  opacity={0.5}
+                  listening={false}
+                />
+              )}
             </Layer>
           </Stage>
         )}

--- a/src/features/drawing/ui/GameCanvas.tsx
+++ b/src/features/drawing/ui/GameCanvas.tsx
@@ -39,6 +39,11 @@ export const GameCanvas = ({
 
   const isCanvasReady = size.width > 0 && size.height > 0;
 
+  /**
+   * 마우스 이동 핸들러
+   * 1. 고스트 커서(미리보기)를 위한 좌표를 업데이트하고 (UI)
+   * 2. 부모로부터 받은 실제 그리기 로직을 실행합니다 (Logic)
+   */
   const handleMouseMoveInternal: KonvaHandler = (event) => {
     const stage = event.target.getStage();
     const position = stage?.getPointerPosition();

--- a/src/features/drawing/ui/GameCanvas.tsx
+++ b/src/features/drawing/ui/GameCanvas.tsx
@@ -5,7 +5,6 @@ import { Layer, Line, Stage } from 'react-konva';
 import { Mannequin } from '@/assets';
 import type { DrawingTool } from '../model/types';
 import { useCanvasSize } from '../model/useCanvasSize';
-import { useDrawing } from '../model/useDrawing';
 import { useTextureLoader } from '../model/useTextureLoader';
 import { BucketResult } from './BucketResult';
 import { CanvasBackground } from './CanvasBackground';
@@ -15,23 +14,25 @@ interface GameCanvasProps {
   activeTool: DrawingTool;
   strokeWidth: number;
   selectedColor: string;
+  lines: any[];
+  onMouseDown: (e: any) => void;
+  onMouseMove: (e: any) => void;
+  onMouseUp: () => void;
 }
 
 export const GameCanvas = ({
+  // TODO: activeTool, strokeWidth, selectedColor 사용 로직 추후 구현
   activeTool,
   strokeWidth,
   selectedColor,
+  lines,
+  onMouseDown,
+  onMouseMove,
+  onMouseUp,
 }: GameCanvasProps) => {
   const containerRef = useRef<ComponentRef<'div'>>(null);
   const size = useCanvasSize(containerRef);
-
   const { textures } = useTextureLoader();
-
-  const { lines, handleDown, handleMove, handleUp } = useDrawing({
-    tool: activeTool,
-    color: selectedColor,
-    size: strokeWidth,
-  });
 
   const isCanvasReady = size.width > 0 && size.height > 0;
 
@@ -46,14 +47,13 @@ export const GameCanvas = ({
           <Stage
             width={size.width}
             height={size.height}
-            onMouseDown={handleDown}
-            onMouseMove={handleMove}
-            onMouseUp={handleUp}
-            onMouseLeave={handleUp}
-            onTouchStart={handleDown}
-            onTouchMove={handleMove}
-            onTouchEnd={handleUp}
-            onTouchCancel={handleUp}
+            onMouseDown={onMouseDown}
+            onMouseMove={onMouseMove}
+            onMouseUp={onMouseUp}
+            onMouseLeave={onMouseUp}
+            onTouchStart={onMouseDown}
+            onTouchMove={onMouseMove}
+            onTouchEnd={onMouseUp}
           >
             <Layer>
               <CanvasBackground

--- a/src/features/game/index.ts
+++ b/src/features/game/index.ts
@@ -4,4 +4,5 @@ export { GameSubmitButton } from './ui/GameSubmitButton';
 export { GameTimer } from './ui/GameTimer';
 export { InventoryPanel } from './ui/InventoryPanel';
 export { PlayerSidebar } from './ui/PlayerSidebar';
+export { ShortcutGuide } from './ui/ShortcutGuide';
 export { ThemeSelector } from './ui/ThemeSelector';

--- a/src/features/game/index.ts
+++ b/src/features/game/index.ts
@@ -1,4 +1,5 @@
 export * from './constants/game';
+export { DrawingHistoryButtons } from './ui/DrawingHistoryButtons';
 export { GameHeader } from './ui/GameHeader';
 export { GameSubmitButton } from './ui/GameSubmitButton';
 export { GameTimer } from './ui/GameTimer';

--- a/src/features/game/ui/DrawingHistoryButtons.tsx
+++ b/src/features/game/ui/DrawingHistoryButtons.tsx
@@ -1,0 +1,40 @@
+import {
+  ArrowUturnLeftIcon,
+  ArrowUturnRightIcon,
+} from '@heroicons/react/24/solid';
+
+interface DrawingHistoryButtonsProps {
+  undo: () => void;
+  redo: () => void;
+}
+
+export const DrawingHistoryButtons = ({
+  undo,
+  redo,
+}: DrawingHistoryButtonsProps) => {
+  return (
+    <div className="flex gap-2">
+      <button
+        onClick={undo}
+        className="group relative p-3 bg-[#E5E5E5] hover:bg-gray-300 active:bg-gray-400 rounded-full transition-all text-gray-700 disabled:opacity-30 flex items-center justify-center shadow-sm"
+      >
+        <ArrowUturnLeftIcon className="w-5 h-5 stroke-[2.5]" />
+        <span className="absolute -top-12 left-1/2 -translate-x-1/2 px-3 py-1.5 bg-gray-800 text-white text-xs rounded-lg opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none whitespace-nowrap z-50 shadow-xl">
+          실행 취소 (Ctrl + Z)
+          <span className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-gray-800" />
+        </span>
+      </button>
+
+      <button
+        onClick={redo}
+        className="group relative p-3 bg-[#E5E5E5] hover:bg-gray-300 active:bg-gray-400 rounded-full transition-all text-gray-700 disabled:opacity-30 flex items-center justify-center shadow-sm"
+      >
+        <ArrowUturnRightIcon className="w-5 h-5 stroke-[2.5]" />
+        <span className="absolute -top-12 left-1/2 -translate-x-1/2 px-3 py-1.5 bg-gray-800 text-white text-xs rounded-lg opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none whitespace-nowrap z-50 shadow-xl">
+          다시 실행 (Ctrl + Shift + Z)
+          <span className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-gray-800" />
+        </span>
+      </button>
+    </div>
+  );
+};

--- a/src/features/game/ui/ShortcutGuide.tsx
+++ b/src/features/game/ui/ShortcutGuide.tsx
@@ -1,0 +1,58 @@
+import { QuestionMarkCircleIcon } from '@heroicons/react/24/outline';
+
+export const ShortcutGuide = () => {
+  return (
+    <div className="group relative inline-block">
+      <button className="p-2 text-white transition-colors bg-gray-400 rounded-full shadow-sm border border-gray-100">
+        <QuestionMarkCircleIcon className="w-6 h-6" />
+      </button>
+
+      <div className="absolute top-0 left-full ml-3 w-64 p-4 bg-white rounded-2xl shadow-2xl border border-gray-100 opacity-0 group-hover:opacity-100 pointer-events-none group-hover:pointer-events-auto transition-all duration-200 z-50">
+        <h3 className="font-bold text-lg mb-4 text-gray-800 border-b pb-2">
+          키보드 단축키
+        </h3>
+
+        <div className="space-y-4 text-sm text-gray-700">
+          <section>
+            <p className="font-semibold mb-2 text-gray-500 text-xs uppercase tracking-wider">
+              도구 선택
+            </p>
+            <div className="grid grid-cols-2 gap-y-1.5">
+              <KbdItem kbd="1" desc="연필" />
+              <KbdItem kbd="2" desc="브러시" />
+              <KbdItem kbd="3" desc="네온" />
+              <KbdItem kbd="4" desc="채우기" />
+              <KbdItem kbd="5" desc="지우개" />
+            </div>
+          </section>
+
+          <section>
+            <p className="font-semibold mb-2 text-gray-500 text-xs uppercase tracking-wider">
+              브러시 설정
+            </p>
+            <KbdItem kbd="[ , ]" desc="크기 확대/축소" />
+          </section>
+
+          <section>
+            <p className="font-semibold mb-2 text-gray-500 text-xs uppercase tracking-wider">
+              작업 기록
+            </p>
+            <div className="space-y-1.5">
+              <KbdItem kbd="Ctrl + Z" desc="실행 취소" />
+              <KbdItem kbd="Ctrl + Shift + Z" desc="다시 실행" />
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const KbdItem = ({ kbd, desc }: { kbd: string; desc: string }) => (
+  <div className="flex items-center justify-between pr-4">
+    <span className="text-gray-600">{desc}</span>
+    <kbd className="px-3 py-1 bg-gray-100 border-b-2 border-gray-300 rounded text-[11px] font-sans font-bold text-gray-800 min-w-[24px] text-center">
+      {kbd}
+    </kbd>
+  </div>
+);

--- a/src/widgets/game-drawing/ui/DrawingWidget.tsx
+++ b/src/widgets/game-drawing/ui/DrawingWidget.tsx
@@ -1,12 +1,15 @@
 import { useCallback, useMemo } from 'react';
 
-import { DrawingToolbox, GameCanvas } from '@/features/drawing';
+import { useAuthStore } from '@/entities/user';
+import { DrawingToolbox, GameCanvas, useDrawing } from '@/features/drawing';
 import {
+  DrawingHistoryButtons,
   GameHeader,
   GameSubmitButton,
   GameTimer,
   InventoryPanel,
   PlayerSidebar,
+  ShortcutGuide,
   ThemeSelector,
 } from '@/features/game';
 import { SOCKET_EVENTS, useSocket } from '@/shared/api/socket';
@@ -20,6 +23,7 @@ import { useThemeSelecting } from '../model/useThemeSelecting';
 
 const DrawingWidget = () => {
   const { status, players, endsAt, inventory, currentTheme } = useGameState();
+
   const { socket } = useSocket();
 
   const { isMyTurn } = useThemeSelecting();
@@ -36,10 +40,18 @@ const DrawingWidget = () => {
     setSelectedColor,
   } = useDrawingTools();
 
+  const { lines, undo, redo, handleDown, handleMove, handleUp } = useDrawing({
+    tool: activeTool,
+    color: selectedColor,
+    size: strokeWidth,
+  });
+
   const { localInput, handleInputChange, handleRandomTheme } =
     useThemeInput(isMyTurn);
 
   useDrawingShortcuts({ setActiveTool, setStrokeWidth });
+
+  const { user } = useAuthStore();
 
   const handleComplete = useCallback(() => {
     if (status === 'THEME_SELECTING') {
@@ -75,7 +87,7 @@ const DrawingWidget = () => {
 
   return (
     <div className="w-full h-screen flex justify-between items-center font-ssrm px-20 py-4 overflow-hidden gap-16">
-      <PlayerSidebar players={players} />
+      <PlayerSidebar players={players} currentUserId={user!.id} />
 
       <main className="w-full h-full rounded-3xl bg-white shadow-xl flex flex-col relative overflow-hidden">
         <GameTimer
@@ -96,13 +108,20 @@ const DrawingWidget = () => {
             />
           ) : (
             <>
+              <div className="absolute -top-12 left-6 z-30">
+                <ShortcutGuide />
+              </div>
               <GameCanvas
                 activeTool={activeTool}
                 strokeWidth={strokeWidth}
                 selectedColor={selectedColor}
+                lines={lines}
+                onMouseDown={handleDown}
+                onMouseMove={handleMove}
+                onMouseUp={handleUp}
               />
 
-              <div className="absolute bottom-8 left-1/2 -translate-x-1/2 z-20">
+              <div className="absolute bottom-8 left-1/2 -translate-x-1/2 z-20 flex items-center gap-4">
                 <DrawingToolbox
                   activeTool={activeTool}
                   onToolChange={setActiveTool}
@@ -111,6 +130,7 @@ const DrawingWidget = () => {
                   selectedColor={selectedColor}
                   onColorChange={setSelectedColor}
                 />
+                <DrawingHistoryButtons undo={undo} redo={redo} />
               </div>
             </>
           )}

--- a/src/widgets/game-drawing/ui/DrawingWidget.tsx
+++ b/src/widgets/game-drawing/ui/DrawingWidget.tsx
@@ -114,7 +114,6 @@ const DrawingWidget = () => {
               <GameCanvas
                 activeTool={activeTool}
                 strokeWidth={strokeWidth}
-                selectedColor={selectedColor}
                 lines={lines}
                 onMouseDown={handleDown}
                 onMouseMove={handleMove}


### PR DESCRIPTION
## 📝 작업 내용 (Description)
- 게임 플레이 중 그리기 경험을 개선하기 위해 단축키 가이드와 실행 취소/다시 실행 UI를 추가했습니다. 
- 또한, 사용자가 브러시 크기를 직관적으로 인지할 수 있도록 고스트 커서(미리보기) 기능을 구현했습니다.
- 그리기 관련 Undo, Redo 로직의 아키텍처를 리팩토링했습니다.

## ✨ 변경 사항 (Changes)

- UI 추가:
  - 좌측 상단 ShortcutGuide 컴포넌트 추가 (키보드 단축키 안내).
  - 하단 DrawingHistoryActions 컴포넌트 추가 (Undo/Redo 버튼 및 툴팁).
  - 캔버스 위 마우스 포인터에 브러시 크기 미리보기(Ghost Cursor) 적용.

- 로직 및 구조 개선:
  - useDrawing 훅을 DrawingWidget으로 끌어올려 상태 관리 일원화. (⭐️ Undo/Redo 스택이 StrictMode에서 두 번 호출되던 문제 해결 및 로직 분리).
  - GameCanvas에서 사용하지 않는 Props(selectedColor 등) 제거 및 타입 정의(KonvaHandler) 개선.
  - 환경 설정: ESLint no-unused-vars 규칙을 TypeScript 전용 규칙으로 교체.

## 📸 스크린샷 (Screenshots)
<img width="1822" height="1107" alt="image" src="https://github.com/user-attachments/assets/6a6f223b-c5db-44b3-8428-6b0a260a669c" />

## ✅ 리뷰어 체크리스트 (Reviewer Checklist)
- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?

## 📢 참고 사항 (Notes)

- Ghost Cursor 비율: 커서 원의 크기(radius)는 실제 텍스처 브러시가 찍히는 시각적 크기에 맞춰 strokeWidth / 16으로 조정했습니다.
- ESLint: 타입 정의부의 매개변수를 변수 미사용으로 오인하는 문제를 해결하기 위해 기본 룰을 끄고 TS 룰을 적용했습니다.

## 🧐 이슈 (Related Issues)

- Closes #89
