### PR TITLE
feat: (#105) 게임 총 결산 페이즈: Mock 데이터 추가 및 팀전 총 결산 UI 구현

### DIFF
--- a/src/features/game-finished/model/types.ts
+++ b/src/features/game-finished/model/types.ts
@@ -1,0 +1,10 @@
+import type { Player } from '@/shared/model';
+
+export interface FinishedPlayer extends Player {
+  rank: number;
+  expGained: number;
+  coinsGained: number;
+  didLevelUp: boolean;
+
+  isOnPodium: boolean;
+}

--- a/src/features/game-finished/model/useGameFinished.ts
+++ b/src/features/game-finished/model/useGameFinished.ts
@@ -1,19 +1,12 @@
-import type { FinishContext, Player } from '@/shared/model';
 import { useMemo } from 'react';
 
-export interface GameResultMember extends Player {
-  rank: number;
-  expGained: number;
-  coinsGained: number;
-  didLevelUp: boolean;
-
-  isOnPodium: boolean;
-}
+import type { FinishedPlayer } from './types';
+import type { FinishContext, Player } from '@/shared/model';
 
 export const useGameFinished = (
   players: Player[],
   finishContext: FinishContext | null,
-): GameResultMember[] => {
+): FinishedPlayer[] => {
   const sortedResults = useMemo(() => {
     if (!finishContext || !finishContext.results) return [];
 
@@ -30,7 +23,7 @@ export const useGameFinished = (
     });
 
     return mergedList
-      .filter((item): item is GameResultMember => item !== null)
+      .filter((item): item is FinishedPlayer => item !== null)
       .sort((a, b) => a.rank - b.rank);
   }, [players, finishContext]);
 

--- a/src/features/game-finished/ui/FinishedPhase.tsx
+++ b/src/features/game-finished/ui/FinishedPhase.tsx
@@ -1,88 +1,36 @@
 import { createPortal } from 'react-dom';
 
-import { SoloPodium } from '@/assets';
-import { MOCK_PLAYERS, MOCK_FINISH_CONTEXT } from '@/mocks/finished.mock';
+import type { FinishContext } from '@/shared/model';
+import {
+  MOCK_FINISHED_ROOM_STATE,
+  MOCK_TEAM_FINISHED_ROOM_STATE,
+} from '@/mocks/finished.mock';
 import { useLockBodyScroll } from '@/shared/model/useLockBodyScroll';
-import { FireworksLayer } from './FireworksLayer';
-import { RankRow } from './RankRow';
-import { PodiumSpot } from './PodiumSpot';
-import { BACKGROUND_FIREWORKS, FOREGROUND_FIREWORKS } from '../model/fireworks';
+
 import { useGameFinished } from '../model/useGameFinished';
+import { SoloGameResult } from './SoloGameResult';
+import { TeamGameResult } from './TeamGameResult';
 
 export const FinishedPhase = () => {
-  const results = useGameFinished(MOCK_PLAYERS, MOCK_FINISH_CONTEXT);
+  const currentRoomState = MOCK_TEAM_FINISHED_ROOM_STATE;
 
-  const podiumMembers = results.filter((r) => r.rank <= 3);
-  const listMembers = results.filter((r) => r.rank > 3);
+  const { players, phaseContext, settings, teamScore } = currentRoomState;
 
-  const getPodiumMember = (rank: number) =>
-    podiumMembers.find((r) => r.rank === rank);
+  const finishContext = phaseContext as FinishContext;
 
-  const firstPlace = getPodiumMember(1);
-  const secondPlace = getPodiumMember(2);
-  const thirdPlace = getPodiumMember(3);
+  const results = useGameFinished(players, finishContext);
+
+  const isTeamMode = true;
 
   useLockBodyScroll();
 
   return createPortal(
     <div className="fixed inset-0 z-[9999] w-screen h-screen bg-black/90 flex flex-col items-center justify-center gap-8 animate-in fade-in duration-500 pb-24 overflow-y-auto">
-      <div className="relative w-[1000px]">
-        <FireworksLayer items={BACKGROUND_FIREWORKS} />
-        <img
-          src={SoloPodium}
-          alt="Game Finished Podium"
-          className="w-full object-contain drop-shadow-2xl"
-        />
-
-        {firstPlace && (
-          <PodiumSpot
-            rank={1}
-            nickname={firstPlace.nickname}
-            coins={firstPlace.coinsGained}
-            xp={firstPlace.expGained}
-            score={firstPlace.totalScore}
-          />
-        )}
-
-        {secondPlace && (
-          <PodiumSpot
-            rank={2}
-            nickname={secondPlace.nickname}
-            coins={secondPlace.coinsGained}
-            xp={secondPlace.expGained}
-            score={secondPlace.totalScore}
-          />
-        )}
-
-        {thirdPlace && (
-          <PodiumSpot
-            rank={3}
-            nickname={thirdPlace.nickname}
-            coins={thirdPlace.coinsGained}
-            xp={thirdPlace.expGained}
-            score={thirdPlace.totalScore}
-          />
-        )}
-
-        {listMembers.map((member, index) => {
-          const topPosition = 120 + index * 80;
-
-          return (
-            <RankRow
-              key={member.userId}
-              rank={member.rank}
-              nickname={member.nickname}
-              coins={member.coinsGained}
-              xp={member.expGained}
-              score={member.totalScore}
-              className="absolute left-1/2 -translate-x-1/2"
-              style={{ top: `${topPosition}%` }}
-            />
-          );
-        })}
-
-        <FireworksLayer items={FOREGROUND_FIREWORKS} />
-      </div>
+      {isTeamMode ? (
+        <TeamGameResult results={results} teamScore={teamScore} />
+      ) : (
+        <SoloGameResult results={results} />
+      )}
     </div>,
     document.body,
   );

--- a/src/features/game-finished/ui/RankRow.tsx
+++ b/src/features/game-finished/ui/RankRow.tsx
@@ -11,6 +11,8 @@ interface RankRowProps {
   score: number;
   className?: string;
   style?: CSSProperties;
+  rankText?: string;
+  teamId?: string | null;
 }
 
 export const RankRow = ({
@@ -21,7 +23,20 @@ export const RankRow = ({
   score,
   className,
   style,
+  rankText,
+  teamId,
 }: RankRowProps) => {
+  let expBgColor = 'bg-[#6B8E8E]';
+  let pointColor = 'text-[#525252]';
+
+  if (teamId === 'RED') {
+    expBgColor = 'bg-[#FB6464]';
+    pointColor = 'text-[#FB6464]';
+  } else if (teamId === 'BLUE') {
+    expBgColor = 'bg-[#64ACFF]';
+    pointColor = 'text-[#64ACFF]';
+  }
+
   return (
     <div
       style={style}
@@ -29,10 +44,10 @@ export const RankRow = ({
     >
       <div className="flex items-center gap-10">
         <span className="font-ssrm font-bold text-[#525252] text-4xl w-16 text-center">
-          {rank}th
+          {rankText ? rankText : `${rank}th`}
         </span>
+
         <div className="w-16 h-16 bg-white rounded-full overflow-hidden flex items-center justify-center border-2 border-white shadow-sm">
-          {/* TODO: Bird 이미지도 받아오도록 설정 */}
           <img
             src={Bird}
             alt="avatar"
@@ -52,16 +67,18 @@ export const RankRow = ({
           </span>
         </div>
 
-        <div className="bg-[#6B8E8E] px-4 py-1 rounded-full flex items-center justify-center">
+        <div
+          className={`${expBgColor} px-4 py-1 rounded-full flex items-center justify-center`}
+        >
           <span className="font-ssrm font-bold text-white text-xl pt-0.5">
             +{xp}xp
           </span>
         </div>
 
         <div className="flex items-center ml-16 gap-2 w-16 justify-end">
-          <StarIcon className="w-6 h-6 text-[#525252]" />
-          <span className="font-ssrm font-bold text-[#525252] text-xl pt-1">
-            {score}
+          <StarIcon className={`w-6 h-6 ${pointColor}`} />
+          <span className={`font-ssrm font-bold ${pointColor} text-xl pt-1`}>
+            {(score / 30).toFixed(1)}
           </span>
         </div>
       </div>

--- a/src/features/game-finished/ui/SoloGameResult.tsx
+++ b/src/features/game-finished/ui/SoloGameResult.tsx
@@ -1,0 +1,84 @@
+import { SoloPodium } from '@/assets';
+import { BACKGROUND_FIREWORKS, FOREGROUND_FIREWORKS } from '../model/fireworks';
+import { FireworksLayer } from './FireworksLayer';
+import { SoloPodiumSpot } from './SoloPodiumSpot';
+import { RankRow } from './RankRow';
+import type { FinishedPlayer } from '../model/types';
+
+interface SoloGameResultProps {
+  results: FinishedPlayer[];
+}
+
+export const SoloGameResult = ({ results }: SoloGameResultProps) => {
+  // 랭킹 분류 로직
+  const podiumMembers = results.filter((r) => r.rank <= 3);
+  const listMembers = results.filter((r) => r.rank > 3);
+
+  const getPodiumMember = (rank: number) =>
+    podiumMembers.find((r) => r.rank === rank);
+
+  const firstPlace = getPodiumMember(1);
+  const secondPlace = getPodiumMember(2);
+  const thirdPlace = getPodiumMember(3);
+
+  return (
+    <div className="relative w-[1000px]">
+      <FireworksLayer items={BACKGROUND_FIREWORKS} />
+
+      <img
+        src={SoloPodium}
+        alt="Game Finished Podium"
+        className="w-full object-contain drop-shadow-2xl"
+      />
+
+      {firstPlace && (
+        <SoloPodiumSpot
+          rank={1}
+          nickname={firstPlace.nickname}
+          coins={firstPlace.coinsGained}
+          xp={firstPlace.expGained}
+          score={firstPlace.totalScore}
+        />
+      )}
+
+      {secondPlace && (
+        <SoloPodiumSpot
+          rank={2}
+          nickname={secondPlace.nickname}
+          coins={secondPlace.coinsGained}
+          xp={secondPlace.expGained}
+          score={secondPlace.totalScore}
+        />
+      )}
+
+      {thirdPlace && (
+        <SoloPodiumSpot
+          rank={3}
+          nickname={thirdPlace.nickname}
+          coins={thirdPlace.coinsGained}
+          xp={thirdPlace.expGained}
+          score={thirdPlace.totalScore}
+        />
+      )}
+
+      {listMembers.map((member, index) => {
+        const topPosition = 120 + index * 80;
+
+        return (
+          <RankRow
+            key={member.userId}
+            rank={member.rank}
+            nickname={member.nickname}
+            coins={member.coinsGained}
+            xp={member.expGained}
+            score={member.totalScore}
+            className="absolute left-1/2 -translate-x-1/2"
+            style={{ top: `${topPosition}%` }}
+          />
+        );
+      })}
+
+      <FireworksLayer items={FOREGROUND_FIREWORKS} />
+    </div>
+  );
+};

--- a/src/features/game-finished/ui/SoloPodiumSpot.tsx
+++ b/src/features/game-finished/ui/SoloPodiumSpot.tsx
@@ -24,7 +24,7 @@ interface PodiumSpotProps {
   score: number;
 }
 
-export const PodiumSpot = ({
+export const SoloPodiumSpot = ({
   rank,
   nickname,
   coins,

--- a/src/features/game-finished/ui/TeamGameResult.tsx
+++ b/src/features/game-finished/ui/TeamGameResult.tsx
@@ -1,0 +1,155 @@
+import { StarIcon } from '@heroicons/react/24/solid';
+import { useMemo } from 'react';
+
+import { BluePodium, GoldMedal, RedPodium, SoloPodium } from '@/assets';
+import type { TeamScore } from '@/shared/model';
+
+import { BACKGROUND_FIREWORKS, FOREGROUND_FIREWORKS } from '../model/fireworks';
+import type { FinishedPlayer } from '../model/types';
+import { FireworksLayer } from './FireworksLayer';
+import { RankRow } from './RankRow';
+import { TeamPodiumSpot } from './TeamPodiumSpot';
+
+interface TeamGameResultProps {
+  results: FinishedPlayer[];
+  teamScore: TeamScore | null;
+}
+
+export const TeamGameResult = ({ results, teamScore }: TeamGameResultProps) => {
+  const winningTeamId = useMemo(() => {
+    if (!teamScore) return null;
+    if (teamScore.red > teamScore.blue) return 'RED';
+    if (teamScore.blue > teamScore.red) return 'BLUE';
+    return 'DRAW';
+  }, [teamScore]);
+
+  // 2. [로직] 멤버 분리 (승리팀 vs 패배팀)
+  // podiumMembers: 승리 팀 멤버들 (점수 높은 순)
+  // listMembers: 패배 팀 멤버들
+  const { podiumMembers, listMembers } = useMemo(() => {
+    if (!winningTeamId || winningTeamId === 'DRAW') {
+      return {
+        podiumMembers: results.filter((r) => r.rank <= 3),
+        listMembers: results.filter((r) => r.rank > 3),
+      };
+    }
+
+    const winners = results
+      .filter((r) => r.teamId === winningTeamId)
+      .sort((a, b) => b.totalScore - a.totalScore);
+
+    const losers = results.filter((r) => r.teamId !== winningTeamId);
+
+    return { podiumMembers: winners, listMembers: losers };
+  }, [results, winningTeamId]);
+
+  const firstPlace = podiumMembers[0];
+  const secondPlace = podiumMembers[1];
+  const thirdPlace = podiumMembers[2];
+
+  const getTeamTotalScore = (teamId: string) => {
+    return results
+      .filter((member) => member.teamId === teamId)
+      .reduce((sum, member) => sum + member.totalScore, 0);
+  };
+
+  const redTeamScore = getTeamTotalScore('RED');
+  const blueTeamScore = getTeamTotalScore('BLUE');
+
+  const winningScore = useMemo(() => {
+    if (!teamScore) return 0;
+    return teamScore.red >= teamScore.blue ? redTeamScore : blueTeamScore;
+  }, [teamScore, redTeamScore, blueTeamScore]);
+
+  const PodiumSrc = useMemo(() => {
+    if (!teamScore) return SoloPodium;
+    if (teamScore.red > teamScore.blue) return RedPodium;
+    if (teamScore.blue > teamScore.red) return BluePodium;
+    return SoloPodium;
+  }, [teamScore]);
+
+  return (
+    <div className="relative w-[1000px] mt-20">
+      <FireworksLayer items={BACKGROUND_FIREWORKS} />
+      <img
+        src={PodiumSrc}
+        alt="Game Finished Podium"
+        className="w-full object-contain drop-shadow-2xl"
+      />
+
+      <span className="absolute top-7 left-1/2 -translate-x-1/2 text-3xl text-white font-ssrm font-bold drop-shadow-lg">
+        {winningTeamId === 'RED'
+          ? 'RED TEAM WIN'
+          : winningTeamId === 'BLUE'
+            ? 'BLUE TEAM WIN'
+            : 'DRAW'}
+      </span>
+
+      <div className="absolute -top-[410px] left-1/2 -translate-x-1/2 z-50 flex flex-col items-center">
+        <div className="flex items-center gap-2 mb-2">
+          <StarIcon className="w-6 h-6 text-[#E1D1AE] drop-shadow-[0_4px_4px_rgba(0,0,0,0.5)]" />
+          <span className="font-ssrm font-black text-xl text-[#E1D1AE] drop-shadow-[0_4px_4px_rgba(0,0,0,0.5)] pt-2">
+            {winningScore / 100.0}
+          </span>
+        </div>
+      </div>
+
+      <img
+        src={GoldMedal}
+        alt="Gold Medal"
+        className="absolute -top-[370px] left-1/2 -translate-x-1/2 w-28 h-28 object-contain drop-shadow-lg z-50"
+      />
+
+      {firstPlace && (
+        <TeamPodiumSpot
+          rank={1}
+          nickname={firstPlace.nickname}
+          coins={firstPlace.coinsGained}
+          xp={firstPlace.expGained}
+          teamId={firstPlace.teamId}
+        />
+      )}
+
+      {secondPlace && (
+        <TeamPodiumSpot
+          rank={2}
+          nickname={secondPlace.nickname}
+          coins={secondPlace.coinsGained}
+          xp={secondPlace.expGained}
+          teamId={firstPlace.teamId}
+        />
+      )}
+
+      {thirdPlace && (
+        <TeamPodiumSpot
+          rank={3}
+          nickname={thirdPlace.nickname}
+          coins={thirdPlace.coinsGained}
+          xp={thirdPlace.expGained}
+          teamId={firstPlace.teamId}
+        />
+      )}
+
+      {listMembers.map((member, index) => {
+        const topPosition = 140 + index * 150;
+
+        return (
+          <RankRow
+            key={member.userId}
+            rank={member.rank}
+            rankText="LOSE"
+            nickname={member.nickname}
+            coins={member.coinsGained}
+            xp={member.expGained}
+            score={member.totalScore}
+            className="absolute left-1/2 -translate-x-1/2"
+            style={{ top: `${topPosition}%` }}
+            teamId={member.teamId}
+          />
+        );
+      })}
+
+      <FireworksLayer items={FOREGROUND_FIREWORKS} />
+    </div>
+  );
+};

--- a/src/features/game-finished/ui/TeamGameResult.tsx
+++ b/src/features/game-finished/ui/TeamGameResult.tsx
@@ -23,9 +23,6 @@ export const TeamGameResult = ({ results, teamScore }: TeamGameResultProps) => {
     return 'DRAW';
   }, [teamScore]);
 
-  // 2. [로직] 멤버 분리 (승리팀 vs 패배팀)
-  // podiumMembers: 승리 팀 멤버들 (점수 높은 순)
-  // listMembers: 패배 팀 멤버들
   const { podiumMembers, listMembers } = useMemo(() => {
     if (!winningTeamId || winningTeamId === 'DRAW') {
       return {
@@ -89,7 +86,7 @@ export const TeamGameResult = ({ results, teamScore }: TeamGameResultProps) => {
         <div className="flex items-center gap-2 mb-2">
           <StarIcon className="w-6 h-6 text-[#E1D1AE] drop-shadow-[0_4px_4px_rgba(0,0,0,0.5)]" />
           <span className="font-ssrm font-black text-xl text-[#E1D1AE] drop-shadow-[0_4px_4px_rgba(0,0,0,0.5)] pt-2">
-            {winningScore / 100.0}
+            {(winningScore / 100).toFixed(1)}
           </span>
         </div>
       </div>
@@ -116,7 +113,7 @@ export const TeamGameResult = ({ results, teamScore }: TeamGameResultProps) => {
           nickname={secondPlace.nickname}
           coins={secondPlace.coinsGained}
           xp={secondPlace.expGained}
-          teamId={firstPlace.teamId}
+          teamId={secondPlace.teamId}
         />
       )}
 
@@ -126,7 +123,7 @@ export const TeamGameResult = ({ results, teamScore }: TeamGameResultProps) => {
           nickname={thirdPlace.nickname}
           coins={thirdPlace.coinsGained}
           xp={thirdPlace.expGained}
-          teamId={firstPlace.teamId}
+          teamId={thirdPlace.teamId}
         />
       )}
 

--- a/src/features/game-finished/ui/TeamPodiumSpot.tsx
+++ b/src/features/game-finished/ui/TeamPodiumSpot.tsx
@@ -1,0 +1,107 @@
+import { Bird, Coin, LaurelWreath } from '@/assets';
+
+interface PodiumSpotProps {
+  rank: 1 | 2 | 3;
+  nickname: string;
+  coins: number;
+  xp: number;
+  teamId: string | null;
+}
+
+export const TeamPodiumSpot = ({
+  rank,
+  nickname,
+  coins,
+  xp,
+  teamId,
+}: PodiumSpotProps) => {
+  const badgeBgClass = teamId === 'BLUE' ? 'bg-[#64ACFF]' : 'bg-[#FB6464]';
+
+  if (rank === 1) {
+    return (
+      <div className="absolute bottom-[80%] left-1/2 -translate-x-1/2 w-[275px] h-[275px] bg-transparent">
+        <div
+          className="absolute left-1/2 -translate-x-1/2 bg-gradient-to-b to-transparent z-0 pointer-events-none blur-sm w-[300px] h-[660px] -top-[350px] from-white/80 via-white/50"
+          style={{ clipPath: 'polygon(50% 0%, 50% 0%, 100% 100%, 0% 100%)' }}
+        />
+
+        <img src={Bird} className="relative w-full h-full" alt="bird" />
+
+        <img
+          src={LaurelWreath}
+          className="absolute -top-5 left-[50%] -translate-x-1/2 w-[120px] h-[120px] object-contain"
+          alt="wreath"
+        />
+
+        <span
+          className={`absolute top-12 left-[510px] font-ssrm font-bold text-white text-2xl ${badgeBgClass} px-4 py-1 rounded-[20px] whitespace-nowrap shadow-[inset_0_2px_4px_rgba(0,0,0,0.4)]`}
+        >
+          {nickname}
+        </span>
+
+        <div className="absolute top-[94px] left-[530px] flex items-center justify-end gap-2">
+          <img src={Coin} className="w-5 h-5 object-contain" alt="coin" />
+          <span className="font-ssrm font-bold text-white text-xl drop-shadow-sm">
+            {coins}Coin+{xp}xp
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  if (rank === 2) {
+    return (
+      <div className="absolute bottom-[80%] left-[30%] -translate-x-1/2 w-[275px] h-[275px] bg-transparent">
+        <img src={Bird} className="w-full h-full object-contain" alt="bird" />
+
+        <img
+          src={LaurelWreath}
+          className="absolute -top-5 left-[50%] -translate-x-1/2 w-[120px] h-[120px] object-contain"
+          alt="wreath"
+        />
+
+        <span
+          className={`absolute top-32 left-[710px] font-ssrm font-bold text-white text-2xl ${badgeBgClass} px-4 py-1 rounded-[20px] whitespace-nowrap shadow-[inset_0_2px_4px_rgba(0,0,0,0.4)]`}
+        >
+          {nickname}
+        </span>
+
+        <div className="absolute top-[174px] left-[730px] flex items-center justify-end gap-2">
+          <img src={Coin} className="w-5 h-5 object-contain" alt="coin" />
+          <span className="font-ssrm font-bold text-white text-xl drop-shadow-sm">
+            {coins}Coin+{xp}xp
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  if (rank === 3) {
+    return (
+      <div className="absolute bottom-[80%] right-[30%] translate-x-1/2 w-[275px] h-[275px] bg-transparent">
+        <img src={Bird} className="w-full h-full object-contain" alt="bird" />
+
+        <img
+          src={LaurelWreath}
+          className="absolute -top-5 left-[50%] -translate-x-1/2 w-[120px] h-[120px] object-contain"
+          alt="wreath"
+        />
+
+        <span
+          className={`absolute top-52 left-[310px] font-ssrm font-bold text-white text-2xl ${badgeBgClass} px-4 py-1 rounded-[20px] whitespace-nowrap shadow-[inset_0_2px_4px_rgba(0,0,0,0.4)]`}
+        >
+          {nickname}
+        </span>
+
+        <div className="absolute top-[252px] left-[330px] flex items-center justify-end gap-2">
+          <img src={Coin} className="w-5 h-5 object-contain" alt="coin" />
+          <span className="font-ssrm font-bold text-white text-xl drop-shadow-sm">
+            {coins}Coin+{xp}xp
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  return null;
+};

--- a/src/mocks/finished.mock.ts
+++ b/src/mocks/finished.mock.ts
@@ -1,4 +1,10 @@
-import type { FinishContext, Outfit, Player } from '@/shared/model';
+import type {
+  FinishContext,
+  Outfit,
+  Player,
+  RoomSettings,
+  RoomState,
+} from '@/shared/model';
 
 const createOutfit = (overrides?: Partial<Outfit>): Outfit => ({
   bird: 'bird',
@@ -22,7 +28,7 @@ export const MOCK_PLAYERS: Player[] = [
     teamId: null,
     isConnected: true,
     isReady: true,
-    totalScore: 9.5,
+    totalScore: 290,
     inventory: [],
     outfit: createOutfit({
       bird: 'king_penguin',
@@ -40,13 +46,13 @@ export const MOCK_PLAYERS: Player[] = [
     teamId: null,
     isConnected: true,
     isReady: true,
-    totalScore: 8.5,
+    totalScore: 280,
     inventory: [],
     outfit: createOutfit({ bird: 'sparrow', accessory: 'silver_medal' }),
   },
   {
     userId: 'user_3',
-    nickname: 'EGG', // 3등
+    nickname: 'EGG22', // 3등
     level: 5,
     exp: 20,
     coins: 300,
@@ -54,7 +60,7 @@ export const MOCK_PLAYERS: Player[] = [
     teamId: null,
     isConnected: true,
     isReady: true,
-    totalScore: 8.5,
+    totalScore: 270,
     inventory: [],
     outfit: createOutfit({ bird: 'chick', accessory: 'bronze_medal' }),
   },
@@ -68,7 +74,7 @@ export const MOCK_PLAYERS: Player[] = [
     teamId: null,
     isConnected: true,
     isReady: true,
-    totalScore: 6.5,
+    totalScore: 260,
     inventory: [],
     outfit: createOutfit({ bird: 'duck_white' }),
   },
@@ -82,13 +88,13 @@ export const MOCK_PLAYERS: Player[] = [
     teamId: null,
     isConnected: true,
     isReady: true,
-    totalScore: 6.0,
+    totalScore: 250,
     inventory: [],
     outfit: createOutfit({ bird: 'owl_grey', hat: 'glasses' }),
   },
   {
     userId: 'user_6',
-    nickname: 'EGG',
+    nickname: 'EGG1',
     level: 2,
     exp: 10,
     coins: 50,
@@ -96,7 +102,7 @@ export const MOCK_PLAYERS: Player[] = [
     teamId: null,
     isConnected: true,
     isReady: true,
-    totalScore: 3.5,
+    totalScore: 240,
     inventory: [],
     outfit: createOutfit({ bird: 'parrot_basic' }),
   },
@@ -147,4 +153,47 @@ export const MOCK_FINISH_CONTEXT: FinishContext = {
       didLevelUp: false,
     },
   ],
+};
+
+const MOCK_ROOM_SETTINGS: RoomSettings = {
+  roomTitle: '폴리카소 참 잘하는 집',
+  maxPlayers: 6,
+  gameMode: 'SOLO',
+  isPrivate: false,
+};
+
+const MOCK_TEAM_PLAYERS = MOCK_PLAYERS.map((p, i) => ({
+  ...p,
+  teamId: i % 2 === 0 ? 'RED' : 'BLUE',
+}));
+
+export const MOCK_FINISHED_ROOM_STATE: RoomState = {
+  status: 'FINISHED',
+  hostId: MOCK_PLAYERS[0].userId,
+  endsAt: Date.now() + 1000 * 10,
+
+  settings: MOCK_ROOM_SETTINGS,
+  players: MOCK_PLAYERS,
+  currentRound: 3,
+  totalRounds: 3,
+
+  phaseContext: MOCK_FINISH_CONTEXT,
+
+  teamScore: null,
+};
+
+export const MOCK_TEAM_FINISHED_ROOM_STATE: RoomState = {
+  ...MOCK_FINISHED_ROOM_STATE,
+
+  settings: {
+    ...MOCK_ROOM_SETTINGS,
+    gameMode: 'TEAM',
+  },
+
+  players: MOCK_TEAM_PLAYERS,
+
+  teamScore: {
+    blue: 120,
+    red: 150,
+  },
 };

--- a/src/shared/model/room.ts
+++ b/src/shared/model/room.ts
@@ -25,10 +25,7 @@ export interface RoomState {
     | FinishContext
     | null;
 
-  teamScore: {
-    blue: number;
-    red: number;
-  } | null;
+  teamScore: TeamScore | null;
 }
 
 export type RoomStatus =
@@ -48,3 +45,8 @@ export interface RoomSettings {
 }
 
 export type GameMode = 'SOLO' | 'TEAM';
+
+export interface TeamScore {
+  red: number;
+  blue: number;
+}

--- a/src/widgets/game/ui/GameWidget.tsx
+++ b/src/widgets/game/ui/GameWidget.tsx
@@ -12,6 +12,7 @@ import {
 import { DrawingPhase } from '@/features/game-drawing';
 import { EvaluatingPhase } from '@/features/game-evaluating';
 import { RoundSummaryPhase } from '@/features/game-round-summary';
+import { FinishedPhase } from '@/features/game-finished';
 import { SOCKET_EVENTS, useSocket } from '@/shared/api/socket';
 import { PHASE_TIME } from '@/shared/model';
 import { useGameState } from '../model/useGameState';
@@ -83,7 +84,7 @@ const GameWidget = () => {
         return <RoundSummaryPhase />;
 
       case 'FINISHED':
-        return <div className="text-2xl font-bold">게임 종료! 결과 발표</div>;
+        return <FinishedPhase />;
 
       default:
         return <div className="text-gray-400">로딩 중...</div>;


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- #103 개인전 로직을 기반으로 팀전 결과 화면 및 로직을 구현했습니다.
- 유지보수를 위해 기존 결과 화면 컴포넌트를 개인전(Solo)과 팀전(Team)으로 분리하고 구조를 개편했습니다.
- (⭐️) `TeamGameResult.tsx`: 승리 팀과 패배 팀을 구분하고, 팀원 점수를 합산(reduce)하는 로직을 useMemo로 처리했습니다. 연산 비용이 크진 않지만, 이 로직을 UI 컴포넌트 내에 두는 것이 적절한지 피드백 부탁드립니다.
- (⭐️) `RankRow.tsx`: 기존 RankRow 컴포넌트를 팀전에서도 사용할 수 있도록 teamId와 rankText props를 추가하여 확장했습니다. 내부에서 조건문으로 스타일을 분기 처리했는데, 구조적으로 더 깔끔한 방법이 있을지 궁금합니다.

## ✨ 변경 사항 (Changes)

- 타입 리팩토링: `GameResultMember` → `FinishedPlayer`로 네이밍 변경
- 컴포넌트 분리: `SoloGameResult` / `TeamGameResult` 및 전용 포디움 컴포넌트 분리
- 팀전 UI 구현: 승리 팀 포디움 배치, 패배 팀 리스트(LOSE) 처리, 팀 컬러(Red/Blue) 적용
- 점수 로직: 3라운드 합산 점수를 별점(10점 만점)으로 환산하는 로직 적용 (/30)
- 데이터 연동: `FinishedPhase`에서 모드에 따른 결과 화면 분기 처리

## 📸 스크린샷 (Screenshots)

<img width="1809" height="1107" alt="image" src="https://github.com/user-attachments/assets/9cb3e1c1-fb6d-49d9-836c-78281bccf4ad" />

## ✅ 리뷰어 체크리스트 (Reviewer Checklist)

- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?

## 📢 참고 사항 (Notes)

- 생략하겠습니다!

## 🧐 이슈 (Related Issues)
Closes #105