### PR TITLE
refactor: (#107) 게임 총 결산 페이즈: UI 관련 함수 분리

### DIFF
--- a/src/features/game-finished/constants/styles.ts
+++ b/src/features/game-finished/constants/styles.ts
@@ -71,3 +71,39 @@ export const SPOTLIGHT_STYLES = {
     clipPath: 'polygon(40% 0%, 60% 0%, 100% 100%, 0% 100%)',
   },
 } as const;
+
+export const TEAM_RANK_STYLES = {
+  1: {
+    wrapper:
+      'absolute bottom-[80%] left-1/2 -translate-x-1/2 w-[275px] h-[275px] bg-transparent',
+    badge:
+      'absolute top-12 left-[510px] font-ssrm font-bold text-white text-2xl px-4 py-1 rounded-[20px] whitespace-nowrap shadow-[inset_0_2px_4px_rgba(0,0,0,0.4)]',
+    rewardWrapper:
+      'absolute top-[94px] left-[530px] flex items-center justify-end gap-2',
+  },
+  2: {
+    wrapper:
+      'absolute bottom-[80%] left-[30%] -translate-x-1/2 w-[275px] h-[275px] bg-transparent',
+    badge:
+      'absolute top-32 left-[710px] font-ssrm font-bold text-white text-2xl px-4 py-1 rounded-[20px] whitespace-nowrap shadow-[inset_0_2px_4px_rgba(0,0,0,0.4)]',
+    rewardWrapper:
+      'absolute top-[174px] left-[730px] flex items-center justify-end gap-2',
+  },
+  3: {
+    wrapper:
+      'absolute bottom-[80%] right-[30%] translate-x-1/2 w-[275px] h-[275px] bg-transparent',
+    badge:
+      'absolute top-52 left-[310px] font-ssrm font-bold text-white text-2xl px-4 py-1 rounded-[20px] whitespace-nowrap shadow-[inset_0_2px_4px_rgba(0,0,0,0.4)]',
+    rewardWrapper:
+      'absolute top-[252px] left-[330px] flex items-center justify-end gap-2',
+  },
+};
+
+export const TEAM_SPOTLIGHT_STYLES = {
+  1: {
+    style: 'w-[300px] h-[660px] -top-[350px] from-white/80 via-white/50 block',
+    clipPath: 'polygon(50% 0%, 50% 0%, 100% 100%, 0% 100%)',
+  },
+  2: { style: 'hidden', clipPath: '' },
+  3: { style: 'hidden', clipPath: '' },
+};

--- a/src/features/game-finished/model/useTeamGameResult.ts
+++ b/src/features/game-finished/model/useTeamGameResult.ts
@@ -1,0 +1,65 @@
+import { useMemo } from 'react';
+
+import { BluePodium, RedPodium, SoloPodium } from '@/assets';
+import type { TeamScore } from '@/shared/model';
+
+import type { FinishedPlayer } from '../model/types';
+
+export const useTeamGameResult = (
+  results: FinishedPlayer[],
+  teamScore: TeamScore | null,
+) => {
+  const winningTeamId = useMemo(() => {
+    if (!teamScore) return null;
+    if (teamScore.red > teamScore.blue) return 'RED';
+    if (teamScore.blue > teamScore.red) return 'BLUE';
+    return 'DRAW';
+  }, [teamScore]);
+
+  const { podiumMembers, listMembers } = useMemo(() => {
+    if (!winningTeamId || winningTeamId === 'DRAW') {
+      return {
+        podiumMembers: results.filter((r) => r.rank <= 3),
+        listMembers: results.filter((r) => r.rank > 3),
+      };
+    }
+
+    const winners = results
+      .filter((r) => r.teamId === winningTeamId)
+      .sort((a, b) => b.totalScore - a.totalScore);
+
+    const losers = results.filter((r) => r.teamId !== winningTeamId);
+
+    return { podiumMembers: winners, listMembers: losers };
+  }, [results, winningTeamId]);
+
+  const winningScore = useMemo(() => {
+    if (!teamScore || !winningTeamId || winningTeamId === 'DRAW') return 0;
+
+    return results
+      .filter((member) => member.teamId === winningTeamId)
+      .reduce((sum, member) => sum + member.totalScore, 0);
+  }, [results, teamScore, winningTeamId]);
+
+  const PodiumSrc = useMemo(() => {
+    if (!teamScore) return SoloPodium;
+    if (teamScore.red > teamScore.blue) return RedPodium;
+    if (teamScore.blue > teamScore.red) return BluePodium;
+    return SoloPodium;
+  }, [teamScore]);
+
+  const resultText = useMemo(() => {
+    if (winningTeamId === 'RED') return 'RED TEAM WIN';
+    if (winningTeamId === 'BLUE') return 'BLUE TEAM WIN';
+    return 'DRAW';
+  }, [winningTeamId]);
+
+  return {
+    winningTeamId,
+    podiumMembers,
+    listMembers,
+    winningScore,
+    PodiumSrc,
+    resultText,
+  };
+};

--- a/src/features/game-finished/ui/TeamGameResult.tsx
+++ b/src/features/game-finished/ui/TeamGameResult.tsx
@@ -1,11 +1,11 @@
 import { StarIcon } from '@heroicons/react/24/solid';
-import { useMemo } from 'react';
 
-import { BluePodium, GoldMedal, RedPodium, SoloPodium } from '@/assets';
+import { GoldMedal } from '@/assets';
 import type { TeamScore } from '@/shared/model';
 
 import { BACKGROUND_FIREWORKS, FOREGROUND_FIREWORKS } from '../model/fireworks';
 import type { FinishedPlayer } from '../model/types';
+import { useTeamGameResult } from '../model/useTeamGameResult';
 import { FireworksLayer } from './FireworksLayer';
 import { RankRow } from './RankRow';
 import { TeamPodiumSpot } from './TeamPodiumSpot';
@@ -16,54 +16,12 @@ interface TeamGameResultProps {
 }
 
 export const TeamGameResult = ({ results, teamScore }: TeamGameResultProps) => {
-  const winningTeamId = useMemo(() => {
-    if (!teamScore) return null;
-    if (teamScore.red > teamScore.blue) return 'RED';
-    if (teamScore.blue > teamScore.red) return 'BLUE';
-    return 'DRAW';
-  }, [teamScore]);
-
-  const { podiumMembers, listMembers } = useMemo(() => {
-    if (!winningTeamId || winningTeamId === 'DRAW') {
-      return {
-        podiumMembers: results.filter((r) => r.rank <= 3),
-        listMembers: results.filter((r) => r.rank > 3),
-      };
-    }
-
-    const winners = results
-      .filter((r) => r.teamId === winningTeamId)
-      .sort((a, b) => b.totalScore - a.totalScore);
-
-    const losers = results.filter((r) => r.teamId !== winningTeamId);
-
-    return { podiumMembers: winners, listMembers: losers };
-  }, [results, winningTeamId]);
+  const { podiumMembers, listMembers, winningScore, PodiumSrc, resultText } =
+    useTeamGameResult(results, teamScore);
 
   const firstPlace = podiumMembers[0];
   const secondPlace = podiumMembers[1];
   const thirdPlace = podiumMembers[2];
-
-  const getTeamTotalScore = (teamId: string) => {
-    return results
-      .filter((member) => member.teamId === teamId)
-      .reduce((sum, member) => sum + member.totalScore, 0);
-  };
-
-  const redTeamScore = getTeamTotalScore('RED');
-  const blueTeamScore = getTeamTotalScore('BLUE');
-
-  const winningScore = useMemo(() => {
-    if (!teamScore) return 0;
-    return teamScore.red >= teamScore.blue ? redTeamScore : blueTeamScore;
-  }, [teamScore, redTeamScore, blueTeamScore]);
-
-  const PodiumSrc = useMemo(() => {
-    if (!teamScore) return SoloPodium;
-    if (teamScore.red > teamScore.blue) return RedPodium;
-    if (teamScore.blue > teamScore.red) return BluePodium;
-    return SoloPodium;
-  }, [teamScore]);
 
   return (
     <div className="relative w-[1000px] mt-20">
@@ -75,11 +33,7 @@ export const TeamGameResult = ({ results, teamScore }: TeamGameResultProps) => {
       />
 
       <span className="absolute top-7 left-1/2 -translate-x-1/2 text-3xl text-white font-ssrm font-bold drop-shadow-lg">
-        {winningTeamId === 'RED'
-          ? 'RED TEAM WIN'
-          : winningTeamId === 'BLUE'
-            ? 'BLUE TEAM WIN'
-            : 'DRAW'}
+        {resultText}
       </span>
 
       <div className="absolute -top-[410px] left-1/2 -translate-x-1/2 z-50 flex flex-col items-center">

--- a/src/features/game-finished/ui/TeamPodiumSpot.tsx
+++ b/src/features/game-finished/ui/TeamPodiumSpot.tsx
@@ -1,4 +1,5 @@
 import { Bird, Coin, LaurelWreath } from '@/assets';
+import { TEAM_RANK_STYLES, TEAM_SPOTLIGHT_STYLES } from '../constants/styles';
 
 interface PodiumSpotProps {
   rank: 1 | 2 | 3;
@@ -15,93 +16,36 @@ export const TeamPodiumSpot = ({
   xp,
   teamId,
 }: PodiumSpotProps) => {
+  const styles = TEAM_RANK_STYLES[rank];
+  const spotlight = TEAM_SPOTLIGHT_STYLES[rank];
+
   const badgeBgClass = teamId === 'BLUE' ? 'bg-[#64ACFF]' : 'bg-[#FB6464]';
 
-  if (rank === 1) {
-    return (
-      <div className="absolute bottom-[80%] left-1/2 -translate-x-1/2 w-[275px] h-[275px] bg-transparent">
-        <div
-          className="absolute left-1/2 -translate-x-1/2 bg-gradient-to-b to-transparent z-0 pointer-events-none blur-sm w-[300px] h-[660px] -top-[350px] from-white/80 via-white/50"
-          style={{ clipPath: 'polygon(50% 0%, 50% 0%, 100% 100%, 0% 100%)' }}
-        />
+  return (
+    <div className={styles.wrapper}>
+      <div
+        className={`absolute left-1/2 -translate-x-1/2 bg-gradient-to-b to-transparent z-0 pointer-events-none blur-sm ${spotlight.style}`}
+        style={{
+          clipPath: spotlight.clipPath,
+        }}
+      />
 
-        <img src={Bird} className="relative w-full h-full" alt="bird" />
+      <img src={Bird} className="relative w-full h-full" alt="bird" />
 
-        <img
-          src={LaurelWreath}
-          className="absolute -top-5 left-[50%] -translate-x-1/2 w-[120px] h-[120px] object-contain"
-          alt="wreath"
-        />
+      <img
+        src={LaurelWreath}
+        className="absolute -top-5 left-[50%] -translate-x-1/2 w-[120px] h-[120px] object-contain"
+        alt="wreath"
+      />
 
-        <span
-          className={`absolute top-12 left-[510px] font-ssrm font-bold text-white text-2xl ${badgeBgClass} px-4 py-1 rounded-[20px] whitespace-nowrap shadow-[inset_0_2px_4px_rgba(0,0,0,0.4)]`}
-        >
-          {nickname}
+      <span className={`${styles.badge} ${badgeBgClass}`}>{nickname}</span>
+
+      <div className={styles.rewardWrapper}>
+        <img src={Coin} className="w-5 h-5 object-contain" alt="coin" />
+        <span className="font-ssrm font-bold text-white text-xl drop-shadow-sm">
+          {coins}Coin+{xp}xp
         </span>
-
-        <div className="absolute top-[94px] left-[530px] flex items-center justify-end gap-2">
-          <img src={Coin} className="w-5 h-5 object-contain" alt="coin" />
-          <span className="font-ssrm font-bold text-white text-xl drop-shadow-sm">
-            {coins}Coin+{xp}xp
-          </span>
-        </div>
       </div>
-    );
-  }
-
-  if (rank === 2) {
-    return (
-      <div className="absolute bottom-[80%] left-[30%] -translate-x-1/2 w-[275px] h-[275px] bg-transparent">
-        <img src={Bird} className="w-full h-full object-contain" alt="bird" />
-
-        <img
-          src={LaurelWreath}
-          className="absolute -top-5 left-[50%] -translate-x-1/2 w-[120px] h-[120px] object-contain"
-          alt="wreath"
-        />
-
-        <span
-          className={`absolute top-32 left-[710px] font-ssrm font-bold text-white text-2xl ${badgeBgClass} px-4 py-1 rounded-[20px] whitespace-nowrap shadow-[inset_0_2px_4px_rgba(0,0,0,0.4)]`}
-        >
-          {nickname}
-        </span>
-
-        <div className="absolute top-[174px] left-[730px] flex items-center justify-end gap-2">
-          <img src={Coin} className="w-5 h-5 object-contain" alt="coin" />
-          <span className="font-ssrm font-bold text-white text-xl drop-shadow-sm">
-            {coins}Coin+{xp}xp
-          </span>
-        </div>
-      </div>
-    );
-  }
-
-  if (rank === 3) {
-    return (
-      <div className="absolute bottom-[80%] right-[30%] translate-x-1/2 w-[275px] h-[275px] bg-transparent">
-        <img src={Bird} className="w-full h-full object-contain" alt="bird" />
-
-        <img
-          src={LaurelWreath}
-          className="absolute -top-5 left-[50%] -translate-x-1/2 w-[120px] h-[120px] object-contain"
-          alt="wreath"
-        />
-
-        <span
-          className={`absolute top-52 left-[310px] font-ssrm font-bold text-white text-2xl ${badgeBgClass} px-4 py-1 rounded-[20px] whitespace-nowrap shadow-[inset_0_2px_4px_rgba(0,0,0,0.4)]`}
-        >
-          {nickname}
-        </span>
-
-        <div className="absolute top-[252px] left-[330px] flex items-center justify-end gap-2">
-          <img src={Coin} className="w-5 h-5 object-contain" alt="coin" />
-          <span className="font-ssrm font-bold text-white text-xl drop-shadow-sm">
-            {coins}Coin+{xp}xp
-          </span>
-        </div>
-      </div>
-    );
-  }
-
-  return null;
+    </div>
+  );
 };


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- `TeamGameResult`와, `TeamPodiumSpot` 파일에서 UI 관련 함수와 스타일을 분리하는 작업을 진행하였습니다. 
- (⭐️) 간단한 UI 관련 함수들을 `useTeamGameResult.ts`에 작성해두었습니다. 해당 파일에 대해서 리뷰를 부탁드립니다!

## ✨ 변경 사항 (Changes)

- `TeamGameResult.tsx`, `useTeamGameResult.ts`: tsx 파일로부터 UI 관련 함수 분리
- `TeamPodiumSpot.tsx`, `styles.ts`: 복잡한 tsx 파일 스타일링을 별도의 상수 파일로 분리

## 📸 스크린샷 (Screenshots)

<img width="1809" height="1107" alt="image" src="https://github.com/user-attachments/assets/9f10f2ce-9173-4910-90e9-747c9a34f925" />

## ✅ 리뷰어 체크리스트 (Reviewer Checklist)

- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?

## 📢 참고 사항 (Notes)

- 생략합니다!

## 🧐 이슈 (Related Issues)

- Closes #107 
