### PR TITLE
feat: (#123) 옷장 기초 UI 작성

### DIFF
--- a/src/app/Router.tsx
+++ b/src/app/Router.tsx
@@ -15,6 +15,7 @@ const RoomPage = lazy(() => import('@/pages/RoomPage'));
 const GameWidget = lazy(() => import('@/widgets/game/ui/GameWidget'));
 const FriendPage = lazy(() => import('@/pages/FriendPage'));
 const ShopPage = lazy(() => import('@/pages/ShopPage'));
+const WardrobePage = lazy(() => import('@/pages/WardrobePage'));
 
 const router = createBrowserRouter([
   {
@@ -47,6 +48,10 @@ const router = createBrowserRouter([
       {
         path: '/shop',
         element: <ShopPage />,
+      },
+      {
+        path: '/Wardrobe',
+        element: <WardrobePage />,
       },
       {
         path: '/dev/gameWidget',

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -54,3 +54,20 @@
 .custom-cart-scrollbar::-webkit-scrollbar {
   display: none;
 }
+
+.custom-wardrobe-scrollbar::-webkit-scrollbar {
+  width: 25px;
+}
+
+.custom-wardrobe-scrollbar::-webkit-scrollbar-track {
+  border: 1px solid rgba(255, 255, 255, 0.8);
+  border-radius: 20px;
+  margin-bottom: 40px;
+}
+
+.custom-wardrobe-scrollbar::-webkit-scrollbar-thumb {
+  background: white;
+  border-radius: 20px;
+  border: 3px solid transparent;
+  background-clip: padding-box;
+}

--- a/src/entities/character/index.ts
+++ b/src/entities/character/index.ts
@@ -1,0 +1,1 @@
+export { CharacterPreview } from './ui/CharacterPreview';

--- a/src/entities/character/ui/CharacterPreview.tsx
+++ b/src/entities/character/ui/CharacterPreview.tsx
@@ -1,0 +1,120 @@
+import { Bird } from '@/assets';
+import { cn } from '@/shared/lib';
+
+// TODO: FSD 원칙에 위배되기 때문에 파일 내 작성. 차후 수정 필요합니다.
+interface Product {
+  id: number;
+  name: string;
+  price: number;
+  level: number;
+  subCategory?: string;
+  description?: string;
+  image: string;
+  outfitImage?: string;
+}
+
+interface CharacterPreviewProps {
+  level: number;
+  nickname?: string;
+  previewItems: Product[];
+  onReset?: () => void;
+  showResetButton?: boolean;
+  classNames?: {
+    container?: string;
+    header?: string;
+    levelIcon?: string;
+    levelText?: string;
+    nicknameText?: string;
+    shadow?: string;
+  };
+}
+
+export const CharacterPreview = ({
+  level,
+  nickname = '폴리칵소',
+  previewItems,
+  onReset,
+  showResetButton = true,
+  classNames,
+}: CharacterPreviewProps) => {
+  return (
+    <div
+      className={cn(
+        'flex flex-col items-center bg-white rounded-3xl p-6 pb-4 relative overflow-hidden',
+        classNames?.container,
+      )}
+    >
+      <div
+        className={cn(
+          'flex w-full gap-x-2 z-20 shrink-0',
+          'h-[45px]',
+          classNames?.header,
+        )}
+      >
+        <div
+          className={cn(
+            'bg-yellow-300 rounded-full shrink-0',
+            'w-[45px] h-[45px]',
+            classNames?.levelIcon,
+          )}
+        />
+
+        <div className="flex flex-col justify-center">
+          <span
+            className={cn(
+              'text-black font-bold leading-none',
+              'text-base',
+              classNames?.levelText,
+            )}
+          >
+            Lv.{level}
+          </span>
+
+          <span
+            className={cn(
+              'text-[#535353] leading-none',
+              'text-lg',
+              classNames?.nicknameText,
+            )}
+          >
+            {nickname}
+          </span>
+        </div>
+      </div>
+
+      <div className="relative flex-1 w-full flex items-center justify-center z-10 my-2">
+        <img
+          src={Bird}
+          className="absolute w-[90%] h-auto object-contain z-10"
+          alt="Character"
+        />
+
+        {previewItems.map((item) => (
+          <img
+            key={item.id}
+            src={item.image}
+            className="absolute h-[90%] w-auto object-contain z-20 pointer-events-none"
+            alt={item.name}
+          />
+        ))}
+
+        <div
+          className={cn(
+            'absolute bg-[radial-gradient(ellipse_at_center,rgba(0,0,0,0.35)_0%,transparent_70%)] z-0',
+            'bottom-[2%] w-[60%] h-[10%]',
+            classNames?.shadow,
+          )}
+        />
+      </div>
+
+      {showResetButton && onReset && (
+        <button
+          onClick={onReset}
+          className="flex items-center justify-center rounded-full text-xs px-3 py-1 bg-[#EF5F52] text-white z-20 hover:bg-[#d64538] transition-colors shrink-0 mb-2"
+        >
+          Reset
+        </button>
+      )}
+    </div>
+  );
+};

--- a/src/entities/product/ui/WardrobeItemCard.tsx
+++ b/src/entities/product/ui/WardrobeItemCard.tsx
@@ -1,0 +1,53 @@
+import { cn } from '@/shared/lib';
+import type { Product } from '../model/types';
+
+interface WardrobeItemCardProps {
+  product: Product;
+  isEquipped: boolean;
+  onWear: (product: Product) => void;
+}
+
+export const WardrobeItemCard = ({
+  product,
+  isEquipped,
+  onWear,
+}: WardrobeItemCardProps) => {
+  return (
+    <div
+      onClick={() => onWear(product)}
+      className={cn(
+        'flex flex-col items-center justify-between w-[240px] h-[350px] rounded-[20px] p-5 cursor-pointer transition-all border-2',
+        isEquipped
+          ? 'bg-white border-[#52D843] shadow-[0_0_15px_rgba(82,216,67,0.4)]'
+          : 'bg-white border-transparent hover:scale-[1.02]',
+      )}
+    >
+      <div className="w-full h-[52px] flex gap-x-2">
+        <div className="w-[45px] h-[45px] bg-yellow-300 rounded-full shrink-0"></div>
+        <div className="flex flex-col justify-center flex-1 text-base overflow-hidden">
+          <span className="text-black text-lg font-bold">
+            Lv.{product.level}
+          </span>
+          <span className="text-[#535353] truncate text-xl font-bold">
+            {product.name}
+          </span>
+        </div>
+      </div>
+
+      <img
+        src={product.image}
+        className="flex-1 object-contain px-4 my-2"
+        alt={product.name}
+      />
+
+      <div
+        className={cn(
+          'flex justify-center items-center w-full h-[45px] rounded-lg text-xl font-bold text-white pt-1',
+          isEquipped ? 'bg-[#52D843]' : 'bg-black',
+        )}
+      >
+        {isEquipped ? '착용중' : '착용하기'}
+      </div>
+    </div>
+  );
+};

--- a/src/pages/WardrobePage.tsx
+++ b/src/pages/WardrobePage.tsx
@@ -1,0 +1,124 @@
+import { useMemo } from 'react';
+import { CharacterPreview } from '@/entities/character/ui/CharacterPreview';
+import { useShopPreview } from '@/features/shop/model/useShopPreview';
+import { MOCK_PRODUCTS } from '@/mocks/shop.mock';
+import { WardrobeProductList } from '@/widgets/wardrobe/ui/WardrobeProductList';
+import {
+  useWardrobeFilter,
+  WARDROBE_ITEM_CATEGORIES,
+} from '@/widgets/wardrobe';
+import { cn } from '@/shared/lib';
+
+const USER_LEVEL = 3;
+
+const WardrobePage = () => {
+  const { previewItems, resetPreview, wearItem } = useShopPreview();
+
+  const {
+    activeTab,
+    itemCategory,
+    isDropdownOpen,
+    currentFilterLabel,
+    itemButtonLabel,
+    handleTabChange,
+    toggleDropdown,
+    handleCategorySelect,
+  } = useWardrobeFilter();
+
+  const filteredProducts = useMemo(() => {
+    return MOCK_PRODUCTS.filter(
+      (item) => item.subCategory === currentFilterLabel,
+    );
+  }, [currentFilterLabel]);
+
+  return (
+    <div className="flex items-center justify-center w-full min-h-screen gap-[24px] font-ssrm font-bold">
+      <div className="flex flex-col gap-y-5 w-[500px] h-[720px] rounded-[30px] bg-[#1E3411]/40 shadow-inner p-6">
+        <CharacterPreview
+          level={USER_LEVEL}
+          previewItems={previewItems}
+          showResetButton={false}
+          classNames={{
+            container: 'w-full h-[575px]',
+            shadow: 'top-[380px]',
+            header: 'h-[60px]',
+            levelIcon: 'w-[60px] h-[60px]',
+            levelText: 'text-xl',
+            nicknameText: 'text-2xl',
+          }}
+        />
+
+        <div className="flex justify-between rounded-xl text-3xl p-1.5">
+          <button
+            onClick={resetPreview}
+            className="flex-1 py-3 rounded-full bg-[#2D2D2D] text-white hover:bg-black/90 transition-colors mr-2"
+          >
+            초기화
+          </button>
+          <button className="flex-1 py-3 rounded-full bg-[#EF5F52] text-white hover:bg-[#d64538] transition-colors">
+            확인
+          </button>
+        </div>
+      </div>
+
+      <div className="flex flex-col w-[900px] h-[720px] rounded-[30px] bg-[#1E3411]/40 shadow-inner overflow-visible">
+        <div className="flex items-center w-full h-1/5 gap-x-9 text-3xl relative z-50">
+          <div className="relative ml-10">
+            <button
+              onClick={toggleDropdown}
+              className={cn(
+                'w-[370px] h-[60px] rounded-[20px] transition-colors flex items-center justify-center gap-2',
+                activeTab === 'ITEM'
+                  ? 'bg-[#2D2D2D] text-white'
+                  : 'bg-black hover:bg-[#2D2D2D] text-white',
+              )}
+            >
+              {itemButtonLabel} <span className="text-sm">▼</span>
+            </button>
+
+            {isDropdownOpen && (
+              <div className="absolute top-full mt-2 w-full bg-[#2D2D2D] rounded-[20px] overflow-hidden shadow-xl flex flex-col z-50 animate-in fade-in zoom-in-95 duration-200">
+                {WARDROBE_ITEM_CATEGORIES.map((category) => (
+                  <button
+                    key={category.key}
+                    onClick={() => handleCategorySelect(category.key as any)}
+                    className={cn(
+                      'w-full py-4 text-2xl hover:bg-black/40 transition-colors text-left pl-10',
+                      itemCategory === category.key
+                        ? 'font-black'
+                        : 'text-white',
+                    )}
+                  >
+                    {category.label}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+
+          <button
+            onClick={() => handleTabChange('SKILL')}
+            className={cn(
+              'w-[370px] h-[60px] rounded-[20px] transition-colors',
+              activeTab === 'SKILL'
+                ? 'bg-[#2D2D2D] text-[#52D843] border-2 border-[#52D843]'
+                : 'bg-black hover:bg-[#2D2D2D] text-white',
+            )}
+          >
+            기술
+          </button>
+        </div>
+
+        <div className="flex-1 w-full overflow-hidden pr-8 rounded-[20px] z-0">
+          <WardrobeProductList
+            products={filteredProducts}
+            equippedItems={previewItems}
+            onWearItem={wearItem}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default WardrobePage;

--- a/src/pages/WardrobePage.tsx
+++ b/src/pages/WardrobePage.tsx
@@ -1,8 +1,8 @@
 import { useMemo } from 'react';
-import { CharacterPreview } from '@/entities/character/ui/CharacterPreview';
-import { useShopPreview } from '@/features/shop/model/useShopPreview';
+import { CharacterPreview } from '@/entities/character';
+import { useShopPreview } from '@/features/shop';
 import { MOCK_PRODUCTS } from '@/mocks/shop.mock';
-import { WardrobeProductList } from '@/widgets/wardrobe/ui/WardrobeProductList';
+import { WardrobeProductList } from '@/widgets/wardrobe';
 import {
   useWardrobeFilter,
   WARDROBE_ITEM_CATEGORIES,
@@ -101,7 +101,7 @@ const WardrobePage = () => {
             className={cn(
               'w-[370px] h-[60px] rounded-[20px] transition-colors',
               activeTab === 'SKILL'
-                ? 'bg-[#2D2D2D] text-[#52D843] border-2 border-[#52D843]'
+                ? 'bg-[#2D2D2D] text-white'
                 : 'bg-black hover:bg-[#2D2D2D] text-white',
             )}
           >

--- a/src/widgets/shop/ui/ShopProfilePanel.tsx
+++ b/src/widgets/shop/ui/ShopProfilePanel.tsx
@@ -1,10 +1,11 @@
-import { Bird, Coin } from '@/assets';
+import { Coin } from '@/assets';
+import { CharacterPreview } from '@/entities/character';
 import type { Product } from '@/entities/product';
 import { ShopPurchaseButton } from '@/features/shop-purchase';
 import { cn } from '@/shared/lib';
 
 const USER_BALANCE = 120;
-const USER_LEVEL = 3; // 추가됨
+const USER_LEVEL = 3;
 
 interface ShopProfilePanelProps {
   cart: Product[];
@@ -26,41 +27,16 @@ export const ShopProfilePanel = ({
   return (
     <div className="flex flex-col justify-between w-[360px] h-[720px]">
       <div className="flex flex-col justify-between items-center w-[360px] h-[590px] bg-[#1E3411]/40 rounded-[30px] p-4">
-        <div className="flex flex-col items-center w-[305px] h-[375px] bg-white rounded-3xl p-6 pb-4 relative">
-          <div className="flex w-full h-[45px] gap-x-2 z-20">
-            <div className="w-[45px] h-[45px] bg-yellow-300 rounded-full"></div>
-            <div className="flex flex-col">
-              <span className="text-black text-base">Lv.{USER_LEVEL}</span>
-              <span className="text-[#535353] text-lg">폴리칵소</span>
-            </div>
-          </div>
-
-          <div className="relative flex-1 w-full flex items-center justify-center my-2 z-10">
-            <img
-              src={Bird}
-              className="absolute w-[250px] h-[250px] object-contain z-10"
-              alt="Character"
-            />
-
-            {previewItems.map((item) => (
-              <img
-                key={item.id}
-                src={item.image}
-                className="absolute w-[250px] h-[250px] object-contain z-20 pointer-events-none"
-                alt={item.name}
-              />
-            ))}
-          </div>
-
-          <div className="absolute top-[295px] w-[180px] h-[40px] bg-[radial-gradient(ellipse_at_center,rgba(0,0,0,0.35)_0%,transparent_70%)] z-30" />
-
-          <button
-            onClick={onResetPreview}
-            className="flex items-center justify-center rounded-full text-xs px-3 py-1 bg-[#EF5F52] text-white z-20 hover:bg-[#d64538] transition-colors"
-          >
-            Reset
-          </button>
-        </div>
+        <CharacterPreview
+          level={USER_LEVEL}
+          previewItems={previewItems}
+          onReset={onResetPreview}
+          classNames={{
+            container: 'w-[305px] h-[375px]',
+            shadow: 'top-[220px]',
+            nicknameText: 'text-xl',
+          }}
+        />
 
         <div className="flex items-center w-1/2 h-[35px] bg-[#1E3411]/40 rounded-3xl">
           <img src={Coin} className="w-[40px] h-[40px]" alt="Coin" />
@@ -106,10 +82,9 @@ export const ShopProfilePanel = ({
       <ShopPurchaseButton
         cart={cart}
         userBalance={USER_BALANCE}
-        userLevel={USER_LEVEL} // 추가됨
+        userLevel={USER_LEVEL}
         totalPrice={totalPrice}
         disabled={isCartEmpty}
-        // isOverBudget은 이전 단계에서 ShopPurchaseButton Props에서 제거했으므로 뺐습니다.
       />
     </div>
   );

--- a/src/widgets/wardrobe/constants/category.ts
+++ b/src/widgets/wardrobe/constants/category.ts
@@ -1,0 +1,5 @@
+import { SHOP_CATEGORY_LIST } from '@/features/shop';
+
+export const WARDROBE_ITEM_CATEGORIES = SHOP_CATEGORY_LIST.filter(
+  (c) => c.key !== 'SKILL',
+);

--- a/src/widgets/wardrobe/index.ts
+++ b/src/widgets/wardrobe/index.ts
@@ -1,0 +1,3 @@
+export * from './constants/category';
+export { useWardrobeFilter } from './model/useWardrobeFilter';
+export { WardrobeProductList } from './ui/WardrobeProductList';

--- a/src/widgets/wardrobe/model/useWardrobeFilter.ts
+++ b/src/widgets/wardrobe/model/useWardrobeFilter.ts
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+import { SHOP_CATEGORIES } from '@/features/shop';
+import type { CategoryType } from '@/features/shop';
+
+export const useWardrobeFilter = () => {
+  const [activeTab, setActiveTab] = useState<'ITEM' | 'SKILL'>('ITEM');
+
+  const [itemCategory, setItemCategory] = useState<CategoryType>('TOP');
+
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+
+  const handleTabChange = (tab: 'ITEM' | 'SKILL') => {
+    setActiveTab(tab);
+    if (tab === 'SKILL') {
+      setIsDropdownOpen(false);
+    }
+  };
+
+  const toggleDropdown = () => {
+    if (activeTab === 'SKILL') {
+      setActiveTab('ITEM');
+      setIsDropdownOpen(true);
+    } else {
+      setIsDropdownOpen((prev) => !prev);
+    }
+  };
+
+  const handleCategorySelect = (category: CategoryType) => {
+    setItemCategory(category);
+    setActiveTab('ITEM');
+    setIsDropdownOpen(false);
+  };
+
+  const currentFilterLabel =
+    activeTab === 'SKILL'
+      ? SHOP_CATEGORIES['SKILL']
+      : SHOP_CATEGORIES[itemCategory];
+
+  const itemButtonLabel =
+    activeTab === 'ITEM' ? SHOP_CATEGORIES[itemCategory] : '아이템';
+
+  return {
+    activeTab,
+    itemCategory,
+    isDropdownOpen,
+    currentFilterLabel,
+    itemButtonLabel,
+    handleTabChange,
+    toggleDropdown,
+    handleCategorySelect,
+    setIsDropdownOpen,
+  };
+};

--- a/src/widgets/wardrobe/ui/WardrobeProductList.tsx
+++ b/src/widgets/wardrobe/ui/WardrobeProductList.tsx
@@ -1,0 +1,41 @@
+import { WardrobeItemCard } from '@/entities/product/ui/WardrobeItemCard';
+import type { Product } from '@/entities/product';
+
+interface WardrobeProductListProps {
+  products: Product[];
+  equippedItems: Product[];
+  onWearItem: (product: Product) => void;
+}
+
+export const WardrobeProductList = ({
+  products,
+  equippedItems,
+  onWearItem,
+}: WardrobeProductListProps) => {
+  return (
+    <div className="w-full h-full overflow-y-auto pl-10 pr-6 custom-wardrobe-scrollbar">
+      <div className="grid grid-cols-3 gap-x-[20px] gap-y-[30px] pb-10">
+        {products.length === 0 ? (
+          <div className="col-span-3 h-[400px] flex items-center justify-center text-white/50 text-xl font-bold">
+            보유한 아이템이 없습니다.
+          </div>
+        ) : (
+          products.map((item) => {
+            const isEquipped = equippedItems.some(
+              (equipped) => equipped.id === item.id,
+            );
+
+            return (
+              <WardrobeItemCard
+                key={item.id}
+                product={item}
+                isEquipped={isEquipped}
+                onWear={onWearItem}
+              />
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- 옷장 페이지의 전체적인 레이아웃과 필터링 UI를 구현했습니다.
- 상점과 유사하지만 옷장 기능에 맞는 전용 카드와 리스트를 구성했습니다.
- 현재 작업단위에서는 `useShopPreview.ts`를 사용하고 있습니다. 차후 Zustand로 유저의 의상 정보를 저장하려고 합니다. 작업이 해당 이슈와 연관이 깊어 그 쪽에서 한번 작업해보려 합니다!

## ✨ 변경 사항 (Changes)

- `WardrobePage`: 페이지 레이아웃 및 라우팅 추가
- `WardrobeItemCard`: 옷장 전용 아이템 카드 (가격 표기 제거, 착용 상태 강조)
- `useWardrobeFilter`: 아이템/기술 탭 전환 및 드롭다운 필터 로직 구현
- `CharacterPreview`: 상점과 옷장에서 공통으로 사용할 수 있도록 스타일 확장 (`classNames` 추가)

## 📸 스크린샷 (Screenshots)

<img width="1822" height="1106" alt="image" src="https://github.com/user-attachments/assets/e218e1c5-d355-4100-8e4b-9cac1dcf768f" />

## ✅ 리뷰어 체크리스트 (Reviewer Checklist)

- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?

## 📢 참고 사항 (Notes)

- 생략하겠습니다!

## 🧐 이슈 (Related Issues)

- Closes #123 
