### PR TITLE
feat: (#110) 메인 페이지 방 목록 인원수 표현 로직 변경 및 유저 아바타 추가

### DIFF
--- a/src/entities/room/api/getRoomState.ts
+++ b/src/entities/room/api/getRoomState.ts
@@ -1,0 +1,29 @@
+import { instance } from '@/shared/api';
+import type { RoomStatus } from '../model/types';
+import type { Outfit, RoomSettings, WaitingStatus } from '@/shared/model';
+
+interface GetRoomsStateResponse {
+  status: RoomStatus;
+  hostId: number;
+  settings: RoomSettings;
+  players: WaitingPlayer[];
+}
+
+interface WaitingPlayer {
+  userId: number;
+  nickname: string;
+  team: string;
+  isReady: boolean;
+  level: number;
+  status: WaitingStatus;
+  outfit: Outfit;
+}
+
+export const getRoomState = async (
+  roomId: number,
+): Promise<GetRoomsStateResponse> => {
+  const response = await instance.get<GetRoomsStateResponse>(
+    `rooms/${roomId}/waiting`,
+  );
+  return response.data;
+};

--- a/src/entities/room/queries/roomQueries.ts
+++ b/src/entities/room/queries/roomQueries.ts
@@ -2,6 +2,7 @@ import { infiniteQueryOptions, mutationOptions } from '@tanstack/react-query';
 
 import { createRoom } from '../api/createRoom';
 import { getRooms } from '../api/getRooms';
+import { getRoomState } from '../api/getRoomState';
 import type { RoomFilters } from '../model/types';
 
 export const roomQueries = {
@@ -10,10 +11,35 @@ export const roomQueries = {
   list: (filters: RoomFilters) =>
     infiniteQueryOptions({
       queryKey: [...roomQueries.rooms(), 'list', filters] as const,
-      queryFn: ({ pageParam }) => getRooms({ ...filters, cursor: pageParam }),
+      // 26.01.29: API 이슈로 방 현재인원 받아오지 못함
+      // 현재 존재하는 모든 방의 상세 정보를 조회하여 인원 수를 가져옴
+      // queryFn을 async로 변경하고 로직을 확장
+      queryFn: async ({ pageParam }) => {
+        // 방 리스트 호출
+        const response = await getRooms({ ...filters, cursor: pageParam });
+
+        // 가져온 방들의 id 사용해 각각의 상세 정보 병렬로 호출
+        const roomsWithPlayerCount = await Promise.all(
+          response.rooms.map(async (room) => {
+            try {
+              const detail = await getRoomState(room.id);
+              return {
+                ...room,
+                currentPlayers: detail.players.length, // 기존 데이터에 인원 추가
+              };
+            } catch (error) {
+              return { ...room, currentPlayers: 0 };
+            }
+          }),
+        );
+
+        return {
+          ...response,
+          rooms: roomsWithPlayerCount,
+        };
+      },
 
       initialPageParam: undefined as number | undefined,
-
       getNextPageParam: (lastPage) =>
         lastPage.hasNextPage ? lastPage.nextCursor : undefined,
     }),

--- a/src/entities/user/model/useAuthStore.ts
+++ b/src/entities/user/model/useAuthStore.ts
@@ -5,12 +5,12 @@ import type { Outfit } from '@/shared/model';
 
 const defaultOutfit: Outfit = {
   bird: 'bird_01',
-  accessory: null,
-  hat: null,
-  top: null,
-  bottom: null,
-  shoes: null,
-  effect: null,
+  accessory: 'acc_01',
+  hat: 'hat_01',
+  top: 'top_01',
+  bottom: 'bottom_01',
+  shoes: 'shoes_01',
+  effect: 'effect_01',
 };
 
 export const useAuthStore = create<AuthState>()(

--- a/src/features/main/ui/RoomList/RoomList.tsx
+++ b/src/features/main/ui/RoomList/RoomList.tsx
@@ -57,13 +57,7 @@ export const RoomList = ({ onEnter, onMenu }: Props) => {
       className="
         relative
         mt-5 h-[400px] rounded-2xl overflow-y-auto pr-3
-        scrollbar 
-        scrollbar-thumb-white 
-        hover:scrollbar-thumb-white/90
-        scrollbar-thumb-rounded-full
-        scrollbar-w-5
-        scrollbar-border-2
-        scrollbar-stable
+        custom-scrollbar
       "
     >
       {isLoading ? (

--- a/src/features/main/ui/SideBar.tsx
+++ b/src/features/main/ui/SideBar.tsx
@@ -1,15 +1,17 @@
 import { useNavigate } from 'react-router';
-import { CircleStackIcon, Cog8ToothIcon } from '@heroicons/react/24/solid';
+import { CircleStackIcon } from '@heroicons/react/24/solid';
+import type { Outfit } from '@/shared/model';
+import { getOutfitImageUrl, OUTFIT_LAYERS } from '@/shared/lib/cdn';
 
 interface SideBarProps {
   nickname: string;
   level: number;
   currentXp: number;
   coin: number;
+  outfit: Outfit;
   onLogout: () => void;
 }
 
-// TODO: 레벨별 컬러 및 경험치 등 유틸함수와 상수 정리 필요
 const getMaxXp = (level: number): number => {
   if (level <= 10) return 50;
   if (level <= 20) return 60;
@@ -21,8 +23,9 @@ export const SideBar = ({
   nickname,
   level,
   currentXp,
-  onLogout,
   coin,
+  outfit,
+  onLogout,
 }: SideBarProps) => {
   const maxXp = getMaxXp(level);
   const progress = (currentXp / maxXp) * 100;
@@ -35,7 +38,23 @@ export const SideBar = ({
         <span className="text-2xl">{coin.toLocaleString()}</span>
       </div>
 
-      <div className="w-[225px] h-[225px] rounded-full shadow-lg border-2 border-white bg-white/30" />
+      <div className="relative w-[225px] h-[250px] rounded-full shadow-lg border-2 border-white bg-black/20 overflow-hidden">
+        {OUTFIT_LAYERS.map((layer) => {
+          const partId = outfit[layer];
+
+          if (!partId) return null;
+
+          return (
+            <img
+              key={layer}
+              src={getOutfitImageUrl(partId)}
+              alt={layer}
+              className="absolute object-cover scale-125 top-10"
+              style={{ zIndex: OUTFIT_LAYERS.indexOf(layer) }}
+            />
+          );
+        })}
+      </div>
 
       <div className="flex flex-col w-full mt-6">
         <div className="flex items-end justify-between">
@@ -44,14 +63,12 @@ export const SideBar = ({
               <span className="text-white text-2xl">{level}</span>
             </div>
             <span className="ml-2 text-3xl text-white">{nickname}</span>
-            <button>
-              <Cog8ToothIcon className="w-8 h-8 text-white ml-1 cursor-pointer" />
-            </button>
           </div>
           <span className="text-xs">
             {currentXp}/{maxXp}
           </span>
         </div>
+
         <div className="mt-1 w-full">
           <div className="w-full h-5 rounded-full border border-white/80 p-[2px] overflow-hidden">
             <div
@@ -63,22 +80,22 @@ export const SideBar = ({
       </div>
 
       <div className="flex flex-col w-full mt-4 gap-3 text-3xl">
-        <button className="w-full h-[72px] rounded-full bg-[#6EE035]">
+        <button className="w-full h-[72px] rounded-full bg-[#6EE035] hover:brightness-110 transition-all">
           마이페이지
         </button>
         <button
-          className="w-full h-[72px] rounded-full bg-[#5697FF]"
+          className="w-full h-[72px] rounded-full bg-[#5697FF] hover:brightness-110 transition-all"
           onClick={() => navigate('/shop')}
         >
           상점
         </button>
 
         <div className="flex justify-between gap-3">
-          <button className="flex-1 h-[72px] rounded-full bg-[#FF5353]">
+          <button className="flex-1 h-[72px] rounded-full bg-[#FF5353] hover:brightness-110 transition-all">
             랭킹
           </button>
           <button
-            className="flex-1 h-[72px] rounded-full bg-[#FFBD2F]"
+            className="flex-1 h-[72px] rounded-full bg-[#FFBD2F] hover:brightness-110 transition-all"
             onClick={() => navigate('/friend')}
           >
             친구
@@ -87,7 +104,7 @@ export const SideBar = ({
 
         <button
           onClick={onLogout}
-          className="w-full h-[72px] rounded-full bg-black"
+          className="w-full h-[72px] rounded-full bg-black hover:bg-gray-900 transition-all"
         >
           로그아웃
         </button>

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -39,6 +39,7 @@ const MainPage = () => {
         level={user.level!}
         currentXp={user.currentExp!}
         coin={user.coin!}
+        outfit={user.outfit!}
         onLogout={handleLogout}
       />
 

--- a/src/shared/lib/cdn.ts
+++ b/src/shared/lib/cdn.ts
@@ -1,0 +1,17 @@
+import type { Outfit } from '@/shared/model';
+
+export const CDN_BASE_URL = import.meta.env.VITE_ASSET_CDN_URL;
+
+export const OUTFIT_LAYERS: (keyof Outfit)[] = [
+  'bird',
+  'accessory',
+  'hat',
+  'bottom',
+  'top',
+  'shoes',
+  'effect',
+];
+
+export const getOutfitImageUrl = (id: string) => {
+  return `${CDN_BASE_URL}/outfit_${id}.svg?tr=orig`;
+};


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- 백엔드 리팩터링 이후 메인 페이지의 방 목록이 표시되지 않는 문제가 있었고, 다른 HTTP API를 이용해 방의 상세정보로부터 players 배열의 길이를 가져오는 방식을 채택했습니다. 
- 동시에 #109 #108 작업이 어느정도 진행된 만큼 유저의 아바타가 메인 페이지 사이드바에 드러나도록 작성했습니다.

## ✨ 변경 사항 (Changes)

- `src/shared/lib/cdn.ts`: Outfit 식별자를 통해 유저 아바타 이미지를 cdn에서 가져오는 유틸 함수
- `src/features/main/ui/SideBar.tsx`: 유저 아바타가 사이드바에 나타나도록 작성

## 📸 스크린샷 (Screenshots)

<img width="1822" height="1106" alt="image" src="https://github.com/user-attachments/assets/82c87426-7bfd-4be6-8e8c-3bb4b635e676" />

## ✅ 리뷰어 체크리스트 (Reviewer Checklist)

- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?

## 📢 참고 사항 (Notes)

- 생략합니다!

## 🧐 이슈 (Related Issues)

- Closes #110 
