### PR TITLE
feat: (#151) 친구 페이지 소켓 API 연결

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -5,6 +5,8 @@ import { SocketGlobalAlert } from '@/shared/ui/SocketGlobalAlert';
 import QueryProvider from './queryProvider';
 import Router from './Router';
 import { SocketProvider } from './socketProvider';
+import { FriendSocketProvider } from '@/shared/api/socket/FriendSocketProvider';
+import { ChatSocketProvider } from '@/shared/api/socket/ChatSocketProvider';
 
 const App = () => {
   return (
@@ -12,9 +14,13 @@ const App = () => {
       <SocketProvider>
         <SocketGlobalAlert />
 
-        <OverlayProvider>
-          <Router />
-        </OverlayProvider>
+        <FriendSocketProvider>
+          <ChatSocketProvider>
+            <OverlayProvider>
+              <Router />
+            </OverlayProvider>
+          </ChatSocketProvider>
+        </FriendSocketProvider>
 
         <ToastContainer
           position="top-center"

--- a/src/app/Router.tsx
+++ b/src/app/Router.tsx
@@ -5,7 +5,6 @@ import { RootLayout } from '@/shared/ui/RootLayout';
 import { Spinner } from '@/shared/ui/Spinner';
 import PrivateRoute from './PrivateRoute';
 import { GameSocketProvider } from '@/shared/api/socket/GameSocketProvider';
-import { ChatSocketProvider } from '@/shared/api/socket/ChatSocketProvider';
 
 const LoginPage = lazy(() => import('@/pages/LoginPage'));
 const LoginCallbackPage = lazy(() => import('@/pages/LoginCallbackPage'));
@@ -34,24 +33,20 @@ const router = createBrowserRouter([
       { path: '/auth/callback', element: <LoginCallbackPage /> },
       { path: '/signup', element: <SignupPage /> },
       { path: '/welcome', element: <WelcomePage /> },
-      { path: '/friend', element: <FriendPage /> },
-      { path: '/shop', element: <ShopPage /> },
-      { path: '/Wardrobe', element: <WardrobePage /> },
-      { path: '/dev/gameWidget', element: <GameWidget /> },
-      { path: '/ranking', element: <RankingPage /> },
-      { path: '/mypage', element: <MyPage /> },
 
       {
         element: <PrivateRoute />,
         children: [
           {
-            element: (
-              <ChatSocketProvider>
-                <Outlet />
-              </ChatSocketProvider>
-            ),
+            element: <Outlet />,
             children: [
               { path: '/', element: <MainPage /> },
+              { path: '/friend', element: <FriendPage /> },
+              { path: '/shop', element: <ShopPage /> },
+              { path: '/wardrobe', element: <WardrobePage /> },
+              { path: '/ranking', element: <RankingPage /> },
+              { path: '/mypage', element: <MyPage /> },
+              { path: '/dev/gameWidget', element: <GameWidget /> },
               {
                 path: '/rooms/:roomId',
                 element: (
@@ -71,7 +66,6 @@ const router = createBrowserRouter([
       },
     ],
   },
-
   {
     path: '/admin',
     element: (
@@ -84,7 +78,6 @@ const router = createBrowserRouter([
       </Suspense>
     ),
   },
-
   {
     path: '*',
     element: (

--- a/src/app/socketProvider.tsx
+++ b/src/app/socketProvider.tsx
@@ -10,7 +10,6 @@ export const SocketProvider = ({ children }: { children: ReactNode }) => {
   const socketRef = useRef<Socket | null>(null);
 
   const [isConnected, setIsConnected] = useState(false);
-
   const [messages] = useState<ChatMessage[]>([]);
 
   const token = useAuthStore((state) => state.accessToken);
@@ -45,14 +44,24 @@ export const SocketProvider = ({ children }: { children: ReactNode }) => {
       }
     };
 
+    const handleBeforeUnload = () => {
+      if (socket.connected) {
+        socket.disconnect();
+      }
+    };
+
     socket.on('connect', handleConnect);
     socket.on('disconnect', handleDisconnect);
     socket.on('error', handleError);
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
 
     return () => {
       socket.off('connect', handleConnect);
       socket.off('disconnect', handleDisconnect);
       socket.off('error', handleError);
+
+      window.removeEventListener('beforeunload', handleBeforeUnload);
     };
   }, [token, clearAuth]);
 

--- a/src/entities/friend/constants/events.ts
+++ b/src/entities/friend/constants/events.ts
@@ -1,0 +1,22 @@
+export const FRIEND_ERROR_MESSAGES: Record<string, string> = {
+  ACCESS_TOKEN_MISSING: '로그인이 필요한 서비스입니다.',
+  EXPIRED_ACCESS_TOKEN: '로그인이 만료되었습니다. 다시 로그인해주세요.',
+  INVALID_ACCESS_TOKEN: '로그인 정보가 유효하지 않습니다.',
+
+  INVALID_INPUT: '입력 값이 올바르지 않습니다.',
+  USER_NOT_FOUND: '존재하지 않는 사용자입니다.',
+  CANNOT_REQUEST_SELF: '자기 자신에게는 친구 신청을 할 수 없습니다.',
+  ALREADY_SENT_REQUEST: '이미 친구 신청을 보낸 상대입니다.',
+  ALREADY_FRIEND: '이미 친구 관계인 사용자입니다.',
+
+  BLOCKED_BY_TARGET: '상대방에게 친구 신청을 보낼 수 없는 상태입니다.',
+  BLOCKING_TARGET:
+    '차단한 상대에게는 신청할 수 없습니다. 차단을 먼저 해제해주세요.',
+  ALREADY_BLOCKED: '이미 차단된 사용자입니다.',
+
+  REQUEST_NOT_FOUND: '해당 친구 요청을 찾을 수 없습니다.',
+  CANNOT_CANCEL_RECEIVED_REQUEST: '받은 요청은 취소할 수 없습니다.',
+  CANNOT_RESPOND_OWN_REQUEST: '자신의 요청에는 응답할 수 없습니다.',
+  REQUEST_ALREADY_PROCESSED: '이미 처리된 요청입니다.',
+  NOT_A_FRIEND: '친구 관계가 아닙니다.',
+};

--- a/src/entities/friend/index.ts
+++ b/src/entities/friend/index.ts
@@ -1,3 +1,4 @@
 export * from './model/types';
+export * from './constants/events';
 export { FriendCard } from './ui/FriendCard';
 export { useFriend } from './model/useFriend';

--- a/src/entities/friend/model/friendStore.ts
+++ b/src/entities/friend/model/friendStore.ts
@@ -1,0 +1,64 @@
+import { create } from 'zustand';
+import { Socket } from 'socket.io-client';
+import type { FriendProfile } from './types';
+
+interface FriendStore {
+  friends: FriendProfile[];
+  recommendedFriends: FriendProfile[];
+  searchResults: FriendProfile[];
+  isLoading: boolean;
+
+  setFriends: (friends: FriendProfile[]) => void;
+  setRecommended: (friends: FriendProfile[]) => void;
+  setSearchResults: (results: FriendProfile[]) => void;
+  setLoading: (loading: boolean) => void;
+
+  initListeners: (socket: Socket) => void;
+}
+
+export const useFriendStore = create<FriendStore>((set) => ({
+  friends: [],
+  recommendedFriends: [],
+  searchResults: [],
+  isLoading: true,
+
+  setFriends: (friends) => set({ friends, isLoading: false }),
+  setRecommended: (recommendedFriends) => set({ recommendedFriends }),
+  setSearchResults: (searchResults) => set({ searchResults }),
+  setLoading: (isLoading) => set({ isLoading }),
+
+  initListeners: (socket: Socket) => {
+    if (!socket) return;
+
+    const SYNC_EVENTS = [
+      'friends:statusUpdated',
+      'friends:requestSend',
+      'friends:requestAccept',
+      'friends:delete',
+      'friends:block',
+    ];
+
+    SYNC_EVENTS.forEach((event) => socket.off(event));
+    socket.off('friends:getList');
+    socket.off('friends:getRecommendedList');
+    socket.off('friends:search');
+
+    socket.on('friends:getList', (data) => {
+      set({ friends: data, isLoading: false });
+    });
+
+    socket.on('friends:getRecommendedList', (data) => {
+      set({ recommendedFriends: data });
+    });
+
+    socket.on('friends:search', (data) => {
+      set({ searchResults: data });
+    });
+
+    SYNC_EVENTS.forEach((event) => {
+      socket.on(event, () => {
+        socket.emit('friends:getList');
+      });
+    });
+  },
+}));

--- a/src/entities/friend/model/types.ts
+++ b/src/entities/friend/model/types.ts
@@ -1,3 +1,5 @@
+import type { Outfit } from '@/shared/model';
+
 export type FriendRelation =
   | 'FRIEND'
   | 'REQUEST_SENT'
@@ -7,7 +9,7 @@ export type FriendRelation =
 export interface FriendProfile {
   userId: number | string;
   nickname: string;
-  outfit?: string;
+  outfit: Outfit;
   level: number;
   isOnline: boolean;
 }

--- a/src/entities/friend/model/useFriend.ts
+++ b/src/entities/friend/model/useFriend.ts
@@ -1,167 +1,84 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
-
-import type {
-  FriendAction,
-  FriendProfile,
-  FriendRelation,
-} from '@/entities/friend';
-import { useSocket, SOCKET_EVENTS } from '@/shared/api/socket';
-
-interface Friend extends FriendProfile {
-  relation: FriendRelation;
-}
-
-const RELATION_PRIORITY: Record<FriendRelation, number> = {
-  REQUEST_RECEIVED: 1,
-  REQUEST_SENT: 2,
-  FRIEND: 3,
-  BLOCKED: 5,
-};
+import { useCallback, useEffect, useMemo } from 'react';
+import { useFriendSocket } from '@/shared/api/socket/FriendSocketProvider';
+import { useFriendStore } from './friendStore';
 
 export const useFriend = (searchKeyword: string = '') => {
-  const { socket } = useSocket();
+  const { friendSocket: socket } = useFriendSocket();
+  const {
+    friends,
+    recommendedFriends,
+    searchResults,
+    isLoading,
+    initListeners,
+    setSearchResults,
+  } = useFriendStore();
 
-  const [isLoading, setIsLoading] = useState(true);
-  const [friends, setFriends] = useState<Friend[]>([]);
-  const [recommendedFriends, setRecommendedFriends] = useState<FriendProfile[]>(
-    [],
-  );
-  const [searchResults, setSearchResults] = useState<FriendProfile[]>([]);
-
-  // 소켓 리스너 설정
   useEffect(() => {
     if (!socket) return;
 
-    const handleListResponse = (data: Friend[]) => {
-      setFriends(data);
-      setIsLoading(false);
+    const setup = () => {
+      initListeners(socket);
+
+      socket.emit('friends:getList');
+      socket.emit('friends:getRecommendedList');
     };
 
-    const handleRecommendedResponse = (data: FriendProfile[]) => {
-      setRecommendedFriends(data);
-    };
+    if (socket.connected) {
+      setup();
+    } else {
+      socket.once('connect', setup);
+    }
+  }, [socket, initListeners]);
 
-    const handleSearchResponse = (data: FriendProfile[]) => {
-      setSearchResults(data);
-    };
-
-    const handleStatusUpdate = ({
-      userId,
-      relation,
-    }: {
-      userId: number | string;
-      relation: FriendRelation | 'NONE';
-    }) => {
-      setFriends((prev) => {
-        if (relation === 'NONE') {
-          return prev.filter((f) => f.userId !== userId);
-        }
-        // 기존 목록에 없던 유저(새 친구 등)가 들어올 수도 있으니 체크 필요
-        const exists = prev.find((f) => f.userId === userId);
-        if (!exists && relation === 'FRIEND') {
-          // 실제 앱에선 프로필 정보가 필요하므로 새로고침하거나 서버가 전체 객체를 줘야 함.
-          // 임시로 새로고침 요청
-          socket.emit(SOCKET_EVENTS.FRIEND_GET_ALL);
-          return prev;
-        }
-
-        return prev.map((f) =>
-          f.userId === userId
-            ? { ...f, relation: relation as FriendRelation }
-            : f,
-        );
-      });
-    };
-
-    // 이벤트 구독
-    socket.on(SOCKET_EVENTS.FRIEND_GET_ALL_RESPONSE, handleListResponse);
-    socket.on(SOCKET_EVENTS.FRIEND_STATUS_UPDATE, handleStatusUpdate);
-    socket.on(
-      SOCKET_EVENTS.FRIEND_GET_RECOMMENDED_RESPONSE,
-      handleRecommendedResponse,
-    );
-    socket.on(SOCKET_EVENTS.FRIEND_SEARCH_RESPONSE, handleSearchResponse);
-
-    // 초기 데이터 요청
-    socket.emit(SOCKET_EVENTS.FRIEND_GET_ALL);
-    socket.emit(SOCKET_EVENTS.FRIEND_GET_RECOMMENDED);
-
-    return () => {
-      socket.off(SOCKET_EVENTS.FRIEND_GET_ALL_RESPONSE, handleListResponse);
-      socket.off(SOCKET_EVENTS.FRIEND_STATUS_UPDATE, handleStatusUpdate);
-      socket.off(
-        SOCKET_EVENTS.FRIEND_GET_RECOMMENDED_RESPONSE,
-        handleRecommendedResponse,
-      );
-      socket.off(SOCKET_EVENTS.FRIEND_SEARCH_RESPONSE, handleSearchResponse);
-    };
-  }, [socket]);
-
-  // 액션 핸들러들
-  const handleFriendAction = useCallback(
-    (targetId: number | string, action: FriendAction) => {
+  const requestFriend = useCallback(
+    (targetUserId: number) => {
       if (!socket) return;
-      switch (action) {
-        case 'ACCEPT':
-          socket.emit(SOCKET_EVENTS.FRIEND_ACCEPT, { requesterId: targetId });
-          break;
-        case 'BLOCK':
-          socket.emit(SOCKET_EVENTS.FRIEND_BLOCK, { targetId });
-          break;
-        case 'CANCEL':
-        case 'REJECT':
-        case 'DELETE':
-        case 'UNBLOCK':
-          socket.emit(SOCKET_EVENTS.FRIEND_DELETE, { targetId });
-          break;
-        default:
-          console.warn('Unknown Friend Action:', action);
+      socket.emit('friends:requestSend', { targetUserId });
+    },
+    [socket],
+  );
+
+  const handleFriendAction = useCallback(
+    (
+      targetUserId: number,
+      action: 'ACCEPT' | 'BLOCK' | 'DELETE' | 'CANCEL' | 'REJECT' | 'UNBLOCK',
+    ) => {
+      if (!socket) return;
+
+      const actionMap = {
+        ACCEPT: {
+          event: 'friends:requestAccept',
+          data: { requesterId: targetUserId },
+        },
+        BLOCK: { event: 'friends:block', data: { targetUserId } },
+        DELETE: { event: 'friends:delete', data: { targetUserId } },
+        CANCEL: { event: 'friends:delete', data: { targetUserId } },
+        REJECT: { event: 'friends:delete', data: { targetUserId } },
+        UNBLOCK: { event: 'friends:delete', data: { targetUserId } },
+      };
+
+      const config = actionMap[action];
+      if (config) {
+        socket.emit(config.event, config.data);
       }
     },
     [socket],
   );
-
-  const requestFriend = useCallback(
-    (targetNickname: string) => {
-      if (!socket) return;
-      socket.emit(SOCKET_EVENTS.FRIEND_REQUEST_SEND, { targetNickname });
-    },
-    [socket],
-  );
-
-  const refreshRecommended = useCallback(() => {
-    if (!socket) return;
-    socket.emit(SOCKET_EVENTS.FRIEND_GET_RECOMMENDED);
-  }, [socket]);
 
   const searchUsers = useCallback(
     (keyword: string) => {
-      if (!socket) return;
-      if (!keyword.trim()) {
-        setSearchResults([]);
-        return;
-      }
-      socket.emit(SOCKET_EVENTS.FRIEND_SEARCH, { keyword });
+      if (!keyword.trim()) return setSearchResults([]);
+      socket?.emit('friends:search', { keyword });
     },
-    [socket],
+    [socket, setSearchResults],
   );
 
-  // 필터링 및 정렬 로직 (메모이제이션)
   const processedFriends = useMemo(() => {
-    const filtered = friends.filter((friend) =>
-      friend.nickname.toLowerCase().includes(searchKeyword.toLowerCase()),
-    );
-
-    return [...filtered].sort((a, b) => {
-      const getPriority = (friend: Friend) => {
-        if (friend.relation === 'FRIEND') return friend.isOnline ? 3 : 4;
-        return RELATION_PRIORITY[friend.relation] ?? 99;
-      };
-      const priorityDiff = getPriority(a) - getPriority(b);
-      return priorityDiff !== 0
-        ? priorityDiff
-        : a.nickname.localeCompare(b.nickname);
-    });
+    return friends
+      .filter((f) =>
+        f.nickname.toLowerCase().includes(searchKeyword.toLowerCase()),
+      )
+      .sort((a, b) => a.nickname.localeCompare(b.nickname));
   }, [searchKeyword, friends]);
 
   return {
@@ -171,7 +88,6 @@ export const useFriend = (searchKeyword: string = '') => {
     handleFriendAction,
     requestFriend,
     searchUsers,
-    refreshRecommended,
     isLoading,
   };
 };

--- a/src/entities/friend/ui/FriendCard.tsx
+++ b/src/entities/friend/ui/FriendCard.tsx
@@ -12,6 +12,9 @@ import type {
   FriendRelation,
 } from '../model/types';
 
+// 💡 1. CDN 유틸리티 및 레이어 상수 임포트
+import { getOutfitImageUrl, OUTFIT_LAYERS } from '@/shared/lib/cdn';
+
 interface FriendCardProps extends FriendProfile {
   relation: FriendRelation;
   onAction: (action: FriendAction) => void;
@@ -20,7 +23,7 @@ interface FriendCardProps extends FriendProfile {
 export const FriendCard = ({
   userId,
   nickname,
-  outfit,
+  outfit, // { bird: "...", hat: "...", ... } 객체
   level,
   relation,
   isOnline,
@@ -38,18 +41,29 @@ export const FriendCard = ({
 
   return (
     <div
-      className={`relative flex justify-between p-4 lg:p-5 h-24 lg:h-28 bg-white rounded-xl shadow-sm hover:shadow-md transition-shadow ${relation === 'BLOCKED' ? 'opacity-60 grayscale' : ''}`}
+      className={`relative flex justify-between p-4 lg:p-5 h-24 lg:h-28 bg-white rounded-xl shadow-sm hover:shadow-md transition-shadow ${
+        relation === 'BLOCKED' ? 'opacity-60 grayscale' : ''
+      }`}
     >
       <div className="flex items-center gap-x-3 lg:gap-x-4 overflow-hidden">
-        <div className="shrink-0 w-16 h-16 lg:w-18 lg:h-18 rounded-full bg-gray-100 border border-gray-200 overflow-hidden flex items-center justify-center">
+        <div className="relative shrink-0 w-16 h-16 lg:w-18 lg:h-18 rounded-full bg-black/5 border border-gray-200 overflow-hidden flex items-center justify-center">
           {outfit ? (
-            <img
-              src={outfit}
-              alt="outfit"
-              className="w-full h-full object-cover"
-            />
+            OUTFIT_LAYERS.map((layer) => {
+              const partId = (outfit as any)[layer];
+              if (!partId) return null;
+              return (
+                <img
+                  key={layer}
+                  src={getOutfitImageUrl(partId)}
+                  alt={layer}
+                  // 카드 사이즈(w-16~18)에 맞춰 scale과 top 조절
+                  className="absolute object-cover scale-[1.2] top-3"
+                  style={{ zIndex: OUTFIT_LAYERS.indexOf(layer) }}
+                />
+              );
+            })
           ) : (
-            <span className="text-gray-300 text-xs">No Outfit</span>
+            <span className="text-gray-300 text-xs font-medium">No Outfit</span>
           )}
         </div>
 
@@ -59,12 +73,16 @@ export const FriendCard = ({
           </span>
           <div className="flex items-center gap-x-2 mt-1">
             <span
-              className={`w-12 lg:w-14 h-6 lg:h-7 flex items-center justify-center text-sm text-white lg:text-base rounded-[6px] tabular-nums ${getLevelBadgeColor(level)}`}
+              className={`w-12 lg:w-14 h-6 lg:h-7 flex items-center justify-center text-sm text-white lg:text-base rounded-[6px] tabular-nums ${getLevelBadgeColor(
+                level,
+              )}`}
             >
               {safeTag}
             </span>
             <span
-              className={`text-lg lg:text-xl truncate font-semibold ${isOnline ? 'text-green-500' : 'text-gray-400'}`}
+              className={`text-lg lg:text-xl truncate font-semibold ${
+                isOnline ? 'text-green-500' : 'text-gray-400'
+              }`}
             >
               {isOnline ? '게임 중' : '오프라인'}
             </span>
@@ -72,6 +90,7 @@ export const FriendCard = ({
         </div>
       </div>
 
+      {/* 액션 버튼 영역 (기존 로직 유지) */}
       <div className="shrink-0 flex flex-col items-end justify-start h-full mt-1">
         {relation === 'FRIEND' && (
           <div className="relative">
@@ -122,7 +141,7 @@ export const FriendCard = ({
             onClick={() =>
               handleActionClick('CANCEL', '친구 신청을 취소하시겠습니까?')
             }
-            className="px-3 py-1 bg-gray-700 hover:bg-gray-800 text-white text-sm lg:text-base font-bold rounded-lg transition-colors"
+            className="px-4 py-1.5 bg-gray-700 hover:bg-gray-800 text-white text-sm lg:text-base font-bold rounded-lg transition-colors shadow-sm"
           >
             취소
           </button>
@@ -132,7 +151,7 @@ export const FriendCard = ({
           <div className="flex items-center gap-x-2">
             <button
               onClick={() => handleActionClick('ACCEPT')}
-              className="px-3 py-1 bg-[#2ADB75] hover:bg-[#25c468] text-white text-sm lg:text-base font-bold rounded-lg shadow-sm transition-all"
+              className="px-4 py-1.5 bg-[#2ADB75] hover:bg-[#25c468] text-white text-sm lg:text-base font-bold rounded-lg shadow-md transition-all active:scale-95"
             >
               수락
             </button>
@@ -140,7 +159,7 @@ export const FriendCard = ({
               onClick={() =>
                 handleActionClick('REJECT', '친구 신청을 거절하시겠습니까?')
               }
-              className="px-3 py-1 bg-gray-100 hover:bg-gray-200 text-gray-500 text-sm lg:text-base font-bold rounded-lg transition-colors"
+              className="px-3 py-1.5 bg-gray-100 hover:bg-gray-200 text-gray-500 text-sm lg:text-base font-bold rounded-lg transition-colors"
             >
               거절
             </button>
@@ -152,7 +171,7 @@ export const FriendCard = ({
             onClick={() =>
               handleActionClick('UNBLOCK', '차단을 해제하시겠습니까?')
             }
-            className="text-xs lg:text-sm text-red-500 font-bold border border-red-200 px-2 py-1 rounded hover:bg-red-50 transition-colors"
+            className="text-xs lg:text-sm text-red-500 font-bold border border-red-200 px-2.5 py-1 rounded-md hover:bg-red-50 transition-colors bg-white/50"
           >
             차단됨
           </button>

--- a/src/entities/friend/ui/FriendCard.tsx
+++ b/src/entities/friend/ui/FriendCard.tsx
@@ -4,15 +4,12 @@ import {
   NoSymbolIcon,
   TrashIcon,
 } from '@heroicons/react/24/solid';
-
 import { getLevelBadgeColor } from '../lib/badgeColor';
 import type {
   FriendAction,
   FriendProfile,
   FriendRelation,
 } from '../model/types';
-
-// 💡 1. CDN 유틸리티 및 레이어 상수 임포트
 import { getOutfitImageUrl, OUTFIT_LAYERS } from '@/shared/lib/cdn';
 
 interface FriendCardProps extends FriendProfile {
@@ -23,7 +20,7 @@ interface FriendCardProps extends FriendProfile {
 export const FriendCard = ({
   userId,
   nickname,
-  outfit, // { bird: "...", hat: "...", ... } 객체
+  outfit,
   level,
   relation,
   isOnline,
@@ -49,14 +46,13 @@ export const FriendCard = ({
         <div className="relative shrink-0 w-16 h-16 lg:w-18 lg:h-18 rounded-full bg-black/5 border border-gray-200 overflow-hidden flex items-center justify-center">
           {outfit ? (
             OUTFIT_LAYERS.map((layer) => {
-              const partId = (outfit as any)[layer];
+              const partId = outfit[layer];
               if (!partId) return null;
               return (
                 <img
                   key={layer}
                   src={getOutfitImageUrl(partId)}
                   alt={layer}
-                  // 카드 사이즈(w-16~18)에 맞춰 scale과 top 조절
                   className="absolute object-cover scale-[1.2] top-3"
                   style={{ zIndex: OUTFIT_LAYERS.indexOf(layer) }}
                 />
@@ -90,7 +86,6 @@ export const FriendCard = ({
         </div>
       </div>
 
-      {/* 액션 버튼 영역 (기존 로직 유지) */}
       <div className="shrink-0 flex flex-col items-end justify-start h-full mt-1">
         {relation === 'FRIEND' && (
           <div className="relative">

--- a/src/entities/friend/ui/RecommendedFriendCard.tsx
+++ b/src/entities/friend/ui/RecommendedFriendCard.tsx
@@ -1,7 +1,7 @@
 import { PlusIcon } from '@heroicons/react/24/solid';
-
 import { getLevelBadgeColor } from '../lib/badgeColor';
 import type { FriendProfile } from '../model/types';
+import { getOutfitImageUrl, OUTFIT_LAYERS } from '@/shared/lib/cdn';
 
 interface RecommendedFriendCardProps extends FriendProfile {
   className?: string;
@@ -24,13 +24,22 @@ export const RecommendedFriendCard = ({
   return (
     <div className={`flex items-center justify-between p-4 ${className}`}>
       <div className="flex items-center gap-x-4 overflow-hidden">
-        <div className="shrink-0 w-14 h-14 rounded-full bg-white overflow-hidden flex items-center justify-center border border-gray-200">
+        <div className="relative shrink-0 w-14 h-14 rounded-full bg-black/20 overflow-hidden flex items-center justify-center border border-gray-200">
           {outfit ? (
-            <img
-              src={outfit}
-              alt={`${displayName}의 아바타`}
-              className="w-full h-full object-cover"
-            />
+            OUTFIT_LAYERS.map((layer) => {
+              const partId = outfit[layer];
+              if (!partId) return null;
+
+              return (
+                <img
+                  key={layer}
+                  src={getOutfitImageUrl(partId)}
+                  alt={layer}
+                  className="absolute object-cover scale-[1.1] top-3"
+                  style={{ zIndex: OUTFIT_LAYERS.indexOf(layer) }}
+                />
+              );
+            })
           ) : (
             <div className="w-full h-full bg-gray-100" />
           )}

--- a/src/features/add-friend/ui/AddFriendButton.tsx
+++ b/src/features/add-friend/ui/AddFriendButton.tsx
@@ -2,9 +2,18 @@ import { overlay } from 'overlay-kit';
 
 import { AddFriendModal } from './AddFriendModal';
 
-export const AddFriendButton = () => {
+export const AddFriendButton = ({
+  recommendedFriends,
+}: {
+  recommendedFriends: any[];
+}) => {
   const handleOpen = () => {
-    overlay.open(({ unmount }) => <AddFriendModal onClose={unmount} />);
+    overlay.open(({ unmount }) => (
+      <AddFriendModal
+        onClose={unmount}
+        initialRecommendedFriends={recommendedFriends} // 💡 데이터 주입
+      />
+    ));
   };
 
   return (

--- a/src/features/add-friend/ui/AddFriendModal.tsx
+++ b/src/features/add-friend/ui/AddFriendModal.tsx
@@ -12,58 +12,75 @@ import { useFriend } from '@/entities/friend';
 
 interface AddFriendModalProps {
   onClose: () => void;
+  initialRecommendedFriends: any[]; // 부모로부터 받은 데이터
 }
 
-export const AddFriendModal = ({ onClose }: AddFriendModalProps) => {
-  const { recommendedFriends, requestFriend, searchResults, searchUsers } =
-    useFriend('');
+export const AddFriendModal = ({
+  onClose,
+  initialRecommendedFriends,
+}: AddFriendModalProps) => {
+  // 훅에서 필요한 기능만 가져옴
+  const { requestFriend, searchResults, searchUsers } = useFriend('');
 
-  const [requestedIds, setRequestedIds] = useState<Set<number | string>>(
-    new Set(),
-  );
-
+  // 상태 관리
+  const [requestedIds, setRequestedIds] = useState<Set<number>>(new Set());
   const [searchInput, setSearchInput] = useState('');
-
   const [isSearchMode, setIsSearchMode] = useState(false);
 
-  const handleRequestFriend = (userId: number | string, nickname: string) => {
+  /**
+   * 친구 요청 핸들러
+   * 백엔드 명세에 따라 닉네임이 아닌 userId를 보냅니다.
+   */
+  const handleRequestFriend = (userId: number) => {
     if (requestedIds.has(userId)) return;
 
-    const newSet = new Set(requestedIds);
-    newSet.add(userId);
-    setRequestedIds(newSet);
+    // 요청 보낸 ID 목록에 추가 (UI 피드백)
+    setRequestedIds((prev) => new Set(prev).add(userId));
 
-    requestFriend(nickname);
+    // 실제 소켓 이벤트 송신: { targetUserId: number }
+    requestFriend(userId);
   };
 
+  /**
+   * 검색 실행 핸들러
+   */
   const handleSearch = () => {
-    if (!searchInput.trim()) return;
+    const trimmedKeyword = searchInput.trim();
+    if (!trimmedKeyword) return;
 
     setIsSearchMode(true);
-    searchUsers(searchInput);
+    // 소켓 emit: friends:search { keyword: '...' }
+    searchUsers(trimmedKeyword);
   };
 
+  /**
+   * 입력창 변경 핸들러
+   */
   const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
     setSearchInput(value);
 
+    // 입력창이 비워지면 검색 모드 해제 및 결과 초기화
     if (value.trim() === '') {
       setIsSearchMode(false);
       searchUsers('');
     }
   };
 
-  const displayList = isSearchMode ? searchResults : recommendedFriends;
+  // 현재 보여줄 리스트 결정 (검색 중이면 결과창, 아니면 추천창)
+  const displayList = isSearchMode ? searchResults : initialRecommendedFriends;
 
   return (
     <div
       className="fixed inset-0 flex justify-center items-center bg-black/60 z-50 font-ssrm"
       onClick={onClose}
     >
+      {/* 모달 컨테이너 */}
       <div
         className="relative bg-[#F2F2F2] w-[700px] p-6 rounded-2xl flex flex-col items-center"
         onClick={(e) => e.stopPropagation()}
       >
+        {/* 닫기 버튼 */}
         <button
           onClick={onClose}
           className="absolute top-4 right-4 bg-gray-300 rounded-md p-1 hover:bg-gray-400 transition-colors z-10"
@@ -71,15 +88,17 @@ export const AddFriendModal = ({ onClose }: AddFriendModalProps) => {
           <XMarkIcon className="w-8 h-8 text-white" />
         </button>
 
+        {/* 로고 */}
         <img src={Title} alt="Title" className="w-[450px] my-10" />
 
-        <div className="flex items-center my-3 w-[510px] h-12 bg-white rounded-2xl overflow-hidden ">
+        {/* 검색바 */}
+        <div className="flex items-center my-3 w-[510px] h-12 bg-white rounded-2xl overflow-hidden shadow-sm focus-within:ring-2 focus-within:ring-green-500 transition-all">
           <input
             type="text"
             value={searchInput}
             onChange={handleInputChange}
             onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
-            placeholder="친구의 태그나 이름을 입력해주세요."
+            placeholder="친구의 태그(4자리)나 이름을 입력해주세요."
             autoComplete="off"
             className="flex-1 px-4 text-gray-500 text-xl outline-none placeholder:text-[#BABABA] font-light"
           />
@@ -91,31 +110,27 @@ export const AddFriendModal = ({ onClose }: AddFriendModalProps) => {
           </button>
         </div>
 
+        {/* 리스트 영역 */}
         <div className="mt-3 w-[510px] flex flex-col font-bold">
           <div className="w-full rounded-t-2xl bg-[#153712] text-white text-xl px-4 py-1.5 font-light">
             {isSearchMode ? `'${searchInput}' 검색 결과` : '추천친구'}
           </div>
 
           <div className="w-full h-[350px] overflow-y-auto bg-[#E2E2E2] custom-scrollbar relative">
-            {displayList.length > 0 ? (
+            {displayList && displayList.length > 0 ? (
               displayList.map((friend, index) => (
                 <RecommendedFriendCard
                   key={friend.userId}
-                  userId={friend.userId}
-                  nickname={friend.nickname}
-                  level={friend.level}
-                  isOnline={friend.isOnline}
-                  outfit={friend.outfit}
+                  {...friend} // nickname, level, isOnline, outfit 등 전달
                   className={
                     index % 2 === 0 ? 'bg-[#D9D9D9]/20' : 'bg-[#D4D4D4]'
                   }
                   isRequested={requestedIds.has(friend.userId)}
-                  onAdd={() =>
-                    handleRequestFriend(friend.userId, friend.nickname)
-                  }
+                  onAdd={() => handleRequestFriend(friend.userId)}
                 />
               ))
             ) : (
+              /* 데이터가 없을 때의 Empty State */
               <div className="flex flex-col items-center justify-center h-full text-gray-400 gap-y-3">
                 {isSearchMode ? (
                   <>
@@ -124,7 +139,7 @@ export const AddFriendModal = ({ onClose }: AddFriendModalProps) => {
                       검색된 유저가 없어요.
                     </span>
                     <span className="text-sm text-gray-400 font-normal">
-                      닉네임이나 태그를 다시 확인해주세요.
+                      태그(4자리 숫자)나 이름을 다시 확인해주세요.
                     </span>
                   </>
                 ) : (
@@ -139,6 +154,7 @@ export const AddFriendModal = ({ onClose }: AddFriendModalProps) => {
             )}
           </div>
 
+          {/* 하단 데코레이션 바 */}
           <div className="mb-8 w-full rounded-b-2xl bg-[#153712] h-3" />
         </div>
       </div>

--- a/src/pages/FriendPage.tsx
+++ b/src/pages/FriendPage.tsx
@@ -2,16 +2,22 @@ import { useState } from 'react';
 
 import { BackButton } from '@/features/add-friend/ui/BackButton';
 import { FriendHeader, FriendList } from '@/widgets/friend';
+import { useFriend } from '@/entities/friend';
 
 const FriendPage = () => {
   const [searchKeyword, setSearchKeyword] = useState('');
+  const { recommendedFriends, isLoading } = useFriend('');
 
   return (
     <div className="flex items-center justify-center min-h-screen p-6 md:p-12 font-ssrm font-bold ">
       <BackButton />
       <div className="w-full max-w-[1500px] min-w-[768px] h-[760px] flex flex-col rounded-3xl bg-[#1E3411]/40 overflow-hidden px-5">
-        <FriendHeader value={searchKeyword} onChange={setSearchKeyword} />
-
+        {/* 추천 친구 데이터를 헤더로 넘깁니다 */}
+        <FriendHeader
+          value={searchKeyword}
+          onChange={setSearchKeyword}
+          recommendedFriends={recommendedFriends}
+        />
         <FriendList searchKeyword={searchKeyword} />
       </div>
     </div>

--- a/src/shared/api/socket/FriendSocketProvider.tsx
+++ b/src/shared/api/socket/FriendSocketProvider.tsx
@@ -1,0 +1,56 @@
+import { createContext, useContext, useEffect, useState } from 'react';
+import type { ReactNode } from 'react';
+import type { Socket } from 'socket.io-client';
+import { useAuthStore } from '@/entities/user';
+import { getFriendSocket } from './friendSocketInstance';
+
+interface FriendSocketContextProps {
+  friendSocket: Socket | null;
+  isFriendConnected: boolean;
+}
+
+const FriendSocketContext = createContext<FriendSocketContextProps | null>(
+  null,
+);
+
+export const FriendSocketProvider = ({ children }: { children: ReactNode }) => {
+  const friendSocket = getFriendSocket();
+
+  const [isFriendConnected, setIsFriendConnected] = useState(
+    friendSocket.connected,
+  );
+
+  const token = useAuthStore((state) => state.accessToken);
+
+  useEffect(() => {
+    if (!token || !friendSocket) return;
+
+    friendSocket.auth = { token };
+
+    const handleConnect = () => setIsFriendConnected(true);
+    const handleDisconnect = () => setIsFriendConnected(false);
+
+    friendSocket.on('connect', handleConnect);
+    friendSocket.on('disconnect', handleDisconnect);
+
+    if (!friendSocket.connected) {
+      friendSocket.connect();
+    }
+
+    return () => {
+      friendSocket.off('connect', handleConnect);
+      friendSocket.off('disconnect', handleDisconnect);
+    };
+  }, [token, friendSocket]);
+
+  return (
+    <FriendSocketContext.Provider value={{ friendSocket, isFriendConnected }}>
+      {children}
+    </FriendSocketContext.Provider>
+  );
+};
+
+export const useFriendSocket = () => {
+  const context = useContext(FriendSocketContext);
+  return context || { friendSocket: null, isFriendConnected: false };
+};

--- a/src/shared/api/socket/friendSocketInstance.ts
+++ b/src/shared/api/socket/friendSocketInstance.ts
@@ -1,0 +1,22 @@
+import { useAuthStore } from '@/entities/user';
+import { io, Socket } from 'socket.io-client';
+
+let socket: Socket | null = null;
+
+export const getFriendSocket = (): Socket => {
+  const token = useAuthStore.getState().accessToken;
+
+  if (!socket) {
+    socket = io(`${import.meta.env.VITE_SOCKET_URL}/friends`, {
+      transports: ['websocket'],
+      autoConnect: false,
+      auth: { token },
+    });
+  }
+
+  if (socket) {
+    socket.auth = { token };
+  }
+
+  return socket;
+};

--- a/src/widgets/friend/ui/FriendHeader.tsx
+++ b/src/widgets/friend/ui/FriendHeader.tsx
@@ -6,9 +6,14 @@ import { AddFriendButton } from '@/features/add-friend';
 interface FriendHeaderProps {
   value: string;
   onChange: (value: string) => void;
+  recommendedFriends: any[];
 }
 
-export const FriendHeader = ({ value, onChange }: FriendHeaderProps) => {
+export const FriendHeader = ({
+  value,
+  onChange,
+  recommendedFriends,
+}: FriendHeaderProps) => {
   return (
     <div className="flex items-center justify-between pl-4 pr-5 pt-10 w-full">
       <span className="mb-10 text-white text-5xl font-bold tracking-tight">
@@ -20,7 +25,7 @@ export const FriendHeader = ({ value, onChange }: FriendHeaderProps) => {
           <BellIcon className="w-8 h-8 text-white" />
         </button>
 
-        <AddFriendButton />
+        <AddFriendButton recommendedFriends={recommendedFriends} />
 
         <div className="flex items-center w-[450px] mr-6 h-12 bg-white rounded-2xl overflow-hidden shadow-xl focus-within:ring-2 focus-within:ring-[#2ADB75] transition-all">
           <input


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- 친구 시스템 소켓 인프라를 구축했습니다.
- `/friends` 네임스페이스를 활용하여 전용 소켓 통신 환경을 구축하였습니다.
- 소켓 연결 시점과 리스너 등록 시점의 불일치로 인한 데이터 누락 문제를 해결했습니다.

## ✨ 변경 사항 (Changes)

- `FriendSocketProvider` 도입 및 전역 소켓 레이어 분리
- `Zustand` 기반의 `friendStore`를 통해 친구 목록, 추천 목록, 검색 결과 중앙 집중 관리
- 차단, 삭제, 요청 수락 등 액션 성공 시 서버 응답을 감지하여 즉시 목록을 갱신하는 리스너 로직 구현
- FSD 구조에 따라 `entities/friend` 레이어에 핵심 비즈니스 로직 및 카드 UI 배치

## 📸 스크린샷 (Screenshots)

<img width="1822" height="1092" alt="image" src="https://github.com/user-attachments/assets/4142a34c-7545-4d11-9159-036310eac72d" />

## ✅ 리뷰어 체크리스트 (Reviewer Checklist)

- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?

## 📢 참고 사항 (Notes)

- 생략하겠습니다!

## 🧐 이슈 (Related Issues)

- Closes #151
