### PR TITLE
publish: (#166) 랭킹 페이지 UI 리팩토링

### DIFF
--- a/src/features/ranking/ui/RankingDropdown.tsx
+++ b/src/features/ranking/ui/RankingDropdown.tsx
@@ -8,7 +8,7 @@ interface RankingDropdownProps {
 
 export const RankingDropdown = ({ onSelect }: RankingDropdownProps) => {
   const [isOpen, setIsOpen] = useState(false);
-  const [selected, setSelected] = useState<RankingCriteria>('coins');
+  const [selected, setSelected] = useState<RankingCriteria>('score');
 
   const handleToggle = () => setIsOpen(!isOpen);
 
@@ -22,7 +22,7 @@ export const RankingDropdown = ({ onSelect }: RankingDropdownProps) => {
     selected === 'coins' ? 'score' : 'coins';
 
   return (
-    <div className="absolute top-[231px] right-80 z-20 flex flex-col items-center w-[200px]">
+    <div className="absolute top-[261px] right-[160px] z-20 flex flex-col items-center w-[200px]">
       <div
         className={`
           absolute top-0 w-full bg-[#F2F2F2] rounded-[30px] shadow-md transition-all duration-300 overflow-hidden

--- a/src/features/ranking/ui/RankingHeader.tsx
+++ b/src/features/ranking/ui/RankingHeader.tsx
@@ -1,5 +1,5 @@
 export const RankingHeader = () => (
-  <div className="absolute flex items-center top-[231px] left-[325px] w-[750px] h-[60px] bg-[#69500B] text-white text-xl px-6 rounded-t-xl z-10">
+  <div className="absolute flex items-center top-[260px] left-[150px] w-[750px] h-[60px] bg-[#69500B] text-white text-xl px-6 rounded-t-xl z-10">
     <div className="w-[10%] text-center">등수</div>
     <div className="w-[15%]" />
     <div className="w-[25%] text-center">닉네임</div>

--- a/src/features/ranking/ui/RankingSidebar.tsx
+++ b/src/features/ranking/ui/RankingSidebar.tsx
@@ -8,7 +8,7 @@ export const RankingSidebar = ({
   selectedPeriod: PeriodId;
   onPeriodChange: (id: PeriodId) => void;
 }) => (
-  <div className="absolute flex flex-col right-[166px] top-[230px] gap-y-8 z-0">
+  <div className="absolute flex flex-col -right-3 top-[250px] gap-y-8 z-10">
     {PERIODS.map((period) => (
       <button
         key={period.id}

--- a/src/pages/RankingPage.tsx
+++ b/src/pages/RankingPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import { RankingBoard } from '@/assets';
 import {
   RankingDropdown,
@@ -13,33 +13,65 @@ import { BackButton } from '@/shared/ui/BackButton';
 const RankingPage = () => {
   const [selectedPeriod, setSelectedPeriod] = useState<PeriodId>('daily');
   const [criteria, setCriteria] = useState<RankingCriteria>('score');
+  const [scale, setScale] = useState(1);
+
+  const DESIGN_WIDTH = 1350;
+  const DESIGN_HEIGHT = 950;
+
+  useEffect(() => {
+    const handleResize = () => {
+      const widthScale = window.innerWidth / DESIGN_WIDTH;
+      const heightScale = window.innerHeight / DESIGN_HEIGHT;
+
+      const newScale = Math.min(widthScale, heightScale, 1);
+      setScale(newScale);
+    };
+
+    window.addEventListener('resize', handleResize);
+    handleResize();
+
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
 
   const currentRankings = useMemo(() => {
     return RANKING_MOCK_DATA[criteria][selectedPeriod] || [];
   }, [criteria, selectedPeriod]);
 
   return (
-    <div className="relative flex items-center justify-center w-full min-h-screen font-ssrm font-bold overflow-hidden">
+    <div className="fixed inset-0 w-full h-full flex items-center justify-center font-ssrm font-bold overflow-hidden">
       <BackButton />
+      <div
+        style={{
+          transform: `scale(${scale})`,
+          transformOrigin: 'center center',
+          width: `${DESIGN_WIDTH}px`,
+          height: `${DESIGN_HEIGHT}px`,
+        }}
+        className="relative flex-shrink-0 transition-transform duration-900 ease-out"
+      >
+        <span className="absolute top-[120px] left-1/2 -translate-x-1/2 text-white text-6xl z-10 select-none">
+          RANK
+        </span>
 
-      <span className="absolute top-[88px] text-white text-6xl">RANK</span>
+        <RankingHeader />
+        <RankingDropdown onSelect={(val) => setCriteria(val)} />
+        <RankingSidebar
+          selectedPeriod={selectedPeriod}
+          onPeriodChange={setSelectedPeriod}
+        />
 
-      <RankingHeader />
+        <div className="absolute flex flex-col justify-between items-center bottom-[160px] left-[140px] w-[1090px] h-[470px] text-white text-lg px-10 rounded-t-xl z-10">
+          {currentRankings.map((user, index) => (
+            <RankingRow key={user.username} user={user} index={index} />
+          ))}
+        </div>
 
-      <RankingDropdown onSelect={(val) => setCriteria(val)} />
-
-      <RankingSidebar
-        selectedPeriod={selectedPeriod}
-        onPeriodChange={setSelectedPeriod}
-      />
-
-      <div className="absolute flex flex-col justify-between items-center bottom-[130px] left-[305px] w-[1090px] h-[470px] text-white text-lg px-10 rounded-t-xl z-10">
-        {currentRankings.map((user, index) => (
-          <RankingRow key={user.username} user={user} index={index} />
-        ))}
+        <img
+          src={RankingBoard}
+          alt="Ranking Board"
+          className="absolute inset-0 w-full h-full object-contain pointer-events-none select-none"
+        />
       </div>
-
-      <img src={RankingBoard} alt="Ranking Board" className="w-[1350px]" />
     </div>
   );
 };


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- 랭킹 페이지의 하드코딩된 좌표 시스템이 해상도 변화에 따라 무너지는 문제를 해결하고, 디자인 의도가 유지되도록 고정 캔버스 기반 반응형 UI 리팩토링을 진행했습니다.
- 단순 UI 작업으로 빠르게 머지 진행하도록 하겠습니다.

## ✨ 변경 사항 (Changes)

- `transform: scale()` 기반 작업: 브라우저 크기에 비례하여 UI 전체가 확대/축소되도록 하여 절대 좌표 이탈 차단
- 고정 캔버스 아키텍처 적용: 보드 에셋 크기에 맞춘 독립적 컨테이너를 생성하여 내부 요소의 배치 안정성 확보
- 레이아웃 최적화: 최상위 부모에 `fixed inset-0` 및 `overflow-hidden`을 적용하여 해상도에 따른 불필요한 스크롤바 발생 문제 해결
- 중앙 정렬 로직 개선: `transform-origin: center center` 설정을 통해 모든 디스플레이에서 보드 중앙 배치 보장

## 📸 스크린샷 (Screenshots)

<img width="1822" height="1107" alt="image" src="https://github.com/user-attachments/assets/18c9304d-816c-45fa-97e1-1aafd51fd964" />

## ✅ 리뷰어 체크리스트 (Reviewer Checklist)

- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?

## 📢 참고 사항 (Notes)

- 생략

## 🧐 이슈 (Related Issues)

- Closes #166
