### PR TITLE
feat: (#177) 유저 추가 정보 불러오기 구현

### DIFF
--- a/src/entities/user/model/types.ts
+++ b/src/entities/user/model/types.ts
@@ -4,7 +4,6 @@ export interface User {
   id: number;
   nickname: string;
   tag: string;
-  // TODO: 백엔드 미구현
   coin?: number;
   level?: number;
   currentExp?: number;
@@ -14,10 +13,14 @@ export interface User {
 export interface AuthState {
   user: User | null;
   accessToken: string | null;
+
   setAuth: (data: {
     user: Pick<User, 'id' | 'nickname' | 'tag'>;
     accessToken: string;
   }) => void;
+
+  setProfile: (data: Partial<User>) => void;
+
   updateUser: (data: Partial<User>) => void;
   updateOutfit: (outfit: Partial<Outfit>) => void;
   clearAuth: () => void;

--- a/src/entities/user/model/useAuthStore.ts
+++ b/src/entities/user/model/useAuthStore.ts
@@ -1,17 +1,6 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import type { AuthState } from './types';
-import type { Outfit } from '@/shared/model';
-
-const defaultOutfit: Outfit = {
-  bird: 'bird_01',
-  accessory: 'acc_01',
-  hat: 'hat_01',
-  top: 'top_01',
-  bottom: 'bottom_01',
-  shoes: 'shoes_01',
-  effect: 'effect_01',
-};
 
 export const useAuthStore = create<AuthState>()(
   persist(
@@ -21,33 +10,27 @@ export const useAuthStore = create<AuthState>()(
 
       setAuth: ({ user, accessToken }) =>
         set({
-          user: {
-            ...user,
-            coin: 619,
-            level: 1,
-            currentExp: 0,
-            outfit: defaultOutfit,
-          },
+          user: { ...user },
           accessToken: accessToken,
         }),
+
+      setProfile: (profileData) =>
+        set((state) => ({
+          user: state.user ? { ...state.user, ...profileData } : null,
+        })),
 
       updateUser: (data) =>
         set((state) => ({
           user: state.user ? { ...state.user, ...data } : null,
         })),
 
-      // 특정 부위의 옷만 바꿀 때 사용 (예: 모자만 착용)
       updateOutfit: (newOutfit) =>
         set((state) => {
-          if (!state.user) return state;
-
+          if (!state.user || !state.user.outfit) return state;
           return {
             user: {
               ...state.user,
-              outfit: {
-                ...state.user.outfit,
-                ...newOutfit,
-              } as Outfit,
+              outfit: { ...state.user.outfit, ...newOutfit },
             },
           };
         }),

--- a/src/features/auth/api/getUser.ts
+++ b/src/features/auth/api/getUser.ts
@@ -1,0 +1,13 @@
+import { instance } from '@/shared/api';
+import type { User } from '../model/types';
+
+export const getUser = async (): Promise<User> => {
+  const { data } = await instance.get('/users/me');
+
+  const { coins, ...rest } = data;
+
+  return {
+    ...rest,
+    coin: coins,
+  };
+};

--- a/src/features/auth/model/useLogin.ts
+++ b/src/features/auth/model/useLogin.ts
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import type { AxiosError } from 'axios';
 
 import { useAuthStore } from '@/entities/user';
@@ -13,8 +13,10 @@ import type { LoginFailureResponse } from '../model/types';
 import { authQueries } from '../queries/authQueries';
 
 export const useLogin = () => {
+  const queryClient = useQueryClient();
   const navigate = useNavigate();
   const setAuth = useAuthStore((state) => state.setAuth);
+  const updateUser = useAuthStore((state) => state.updateUser);
 
   const [isAnyFieldFocused, setIsAnyFieldFocused] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
@@ -33,7 +35,7 @@ export const useLogin = () => {
   const { mutate: login, isPending } = useMutation({
     ...authQueries.login(),
 
-    onSuccess: (response) => {
+    onSuccess: async (response) => {
       if (!('accessToken' in response)) {
         setErrorMessage(response.message ?? '로그인에 실패했습니다.');
         return;
@@ -46,6 +48,13 @@ export const useLogin = () => {
         user: { id, nickname, tag },
         accessToken: accessToken,
       });
+
+      try {
+        const profileData = await queryClient.fetchQuery(authQueries.user());
+        updateUser(profileData);
+      } catch (err) {
+        console.error('유저 프로필을 가져오는 데 실패했습니다:', err);
+      }
 
       setErrorMessage(null);
       navigate('/welcome');

--- a/src/features/auth/model/useLoginCallback.ts
+++ b/src/features/auth/model/useLoginCallback.ts
@@ -1,14 +1,16 @@
 import { useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { useAuthStore } from '@/entities/user';
 import { parseAccessToken } from '@/shared/lib';
 import { authQueries } from '../queries/authQueries';
 
 export const useLoginCallback = () => {
+  const queryClient = useQueryClient();
   const navigate = useNavigate();
   const setAuth = useAuthStore((state) => state.setAuth);
+  const updateUser = useAuthStore((state) => state.updateUser);
 
   const isRun = useRef(false);
 
@@ -33,6 +35,9 @@ export const useLoginCallback = () => {
           user: { id, nickname, tag },
           accessToken: accessToken,
         });
+
+        const profileData = await queryClient.fetchQuery(authQueries.user());
+        updateUser(profileData);
 
         navigate('/welcome', { replace: true });
       } catch (error) {

--- a/src/features/auth/model/useSignup.ts
+++ b/src/features/auth/model/useSignup.ts
@@ -12,10 +12,12 @@ import type { SignupFormValues } from '../lib/validators';
 import { signUpSchema } from '../lib/validators';
 import type { SignupFailureResponse } from '../model/types';
 import { authQueries } from '../queries/authQueries';
+import { getUser } from '../api/getUser';
 
 export const useSignup = () => {
   const navigate = useNavigate();
   const setAuth = useAuthStore((state) => state.setAuth);
+  const updateUser = useAuthStore((state) => state.updateUser);
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -63,6 +65,9 @@ export const useSignup = () => {
           user: { id, nickname, tag },
           accessToken: accessToken,
         });
+
+        const profileData = await getUser();
+        updateUser(profileData);
 
         setErrorMessage(null);
         navigate('/welcome');

--- a/src/features/auth/model/useSyncUser.ts
+++ b/src/features/auth/model/useSyncUser.ts
@@ -1,0 +1,21 @@
+import { useQuery } from '@tanstack/react-query';
+import { useEffect } from 'react';
+import { authQueries } from '../queries/authQueries';
+import { useAuthStore } from '@/entities/user';
+
+export const useSyncUser = () => {
+  const setProfile = useAuthStore((state) => state.setProfile);
+  const user = useAuthStore((state) => state.user);
+  const query = useQuery(authQueries.user());
+
+  useEffect(() => {
+    if (query.data) {
+      setProfile(query.data);
+    }
+  }, [query.data, setProfile]);
+
+  return {
+    ...query,
+    isLoggedIn: !!user,
+  };
+};

--- a/src/features/auth/queries/authQueries.ts
+++ b/src/features/auth/queries/authQueries.ts
@@ -1,9 +1,10 @@
-import { mutationOptions } from '@tanstack/react-query';
+import { mutationOptions, queryOptions } from '@tanstack/react-query';
 
 import { postLogin } from '../api/postLogin';
 import { postRefreshToken } from '../api/postRefreshToken';
 import { postSignup } from '../api/postSignup';
 import { postLogout } from '../api/postLogout';
+import { getUser } from '../api/getUser';
 
 export const authQueries = {
   auth: () => ['auth'] as const,
@@ -30,5 +31,11 @@ export const authQueries = {
     mutationOptions({
       mutationKey: [...authQueries.auth(), 'logout'] as const,
       mutationFn: postLogout,
+    }),
+
+  user: () =>
+    queryOptions({
+      queryKey: [...authQueries.auth(), 'user'] as const,
+      queryFn: getUser,
     }),
 };

--- a/src/features/lobby/index.ts
+++ b/src/features/lobby/index.ts
@@ -6,3 +6,4 @@ export { TeamTab } from './ui/TeamTab';
 export { useRoomUI } from './ui/useRoomUI';
 export { NudgeModal } from './ui/NudgeModal';
 export { useNudgeListener } from './model/useNudgeListener';
+export { ScalableText } from './ui/ScalableText';

--- a/src/features/lobby/ui/PlayerSlot.tsx
+++ b/src/features/lobby/ui/PlayerSlot.tsx
@@ -6,7 +6,7 @@ import {
 } from '@heroicons/react/24/solid';
 import { Crown } from '@/assets';
 import { cn } from '@/shared/lib';
-import ScalableText from './ScalableText';
+import { ScalableText } from './ScalableText';
 import { getOutfitImageUrl, OUTFIT_LAYERS } from '@/shared/lib/cdn';
 import type { Player } from '@/shared/model';
 import { getLevelColor } from '@/shared/lib/color';

--- a/src/features/lobby/ui/ScalableText.tsx
+++ b/src/features/lobby/ui/ScalableText.tsx
@@ -8,7 +8,10 @@ interface ScalableTextProps {
   className?: string;
 }
 
-const ScalableText = ({ children, className = '' }: ScalableTextProps) => {
+export const ScalableText = ({
+  children,
+  className = '',
+}: ScalableTextProps) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const textRef = useRef<HTMLSpanElement>(null);
   const [scale, setScale] = useState<number>(1);
@@ -44,5 +47,3 @@ const ScalableText = ({ children, className = '' }: ScalableTextProps) => {
     </div>
   );
 };
-
-export default ScalableText;

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -82,6 +82,7 @@ const MainPage = () => {
     <div className="flex items-center justify-center min-w-[1500px] mx-auto min-h-screen gap-x-10 font-ssrm font-bold">
       <Sidebar
         nickname={user.nickname}
+        tag={user.tag!}
         level={user.level!}
         currentXp={user.currentExp!}
         coin={user.coin!}

--- a/src/widgets/sidebar/ui/Sidebar.tsx
+++ b/src/widgets/sidebar/ui/Sidebar.tsx
@@ -5,6 +5,7 @@ import { Coin } from '@/assets';
 import { useSound } from '@/entities/sound';
 import { SoundManager } from '@/shared/api/sound/manager';
 import { SOUND_ASSETS } from '@/shared/api/sound/assets';
+import { ScalableText } from '@/features/lobby';
 
 interface MenuItem {
   label: string;
@@ -38,6 +39,7 @@ const MENU_CONFIG: Record<'main' | 'mypage', MenuItem[]> = {
 
 interface SideBarProps {
   nickname: string;
+  tag: string;
   level: number;
   currentXp: number;
   coin: number;
@@ -55,6 +57,7 @@ const getMaxXp = (level: number): number => {
 
 export const Sidebar = ({
   nickname,
+  tag,
   level,
   currentXp,
   coin,
@@ -104,14 +107,20 @@ export const Sidebar = ({
       </div>
 
       <div className="flex flex-col w-full mt-6">
-        <div className="flex items-end justify-between">
-          <div className="flex items-center mb-1">
-            <div className="w-[35px] h-[35px] ml-2 rounded-full bg-gray-400 border border-white flex items-center justify-center">
-              <span className="text-white text-2xl">{level}</span>
+        <div className="flex items-end justify-between gap-2">
+          <div className="flex items-center mb-1 flex-1 min-w-0">
+            <div className="flex-shrink-0 w-[35px] h-[35px] rounded-full bg-gray-400 border border-white flex items-center justify-center">
+              <span className="text-white text-2xl font-bold">{level}</span>
             </div>
-            <span className="ml-2 text-3xl text-white">{nickname}</span>
+
+            <div className="flex-1 min-w-0 h-10 ml-2">
+              <ScalableText className="text-3xl text-white font-bold">
+                {nickname}#{tag}
+              </ScalableText>
+            </div>
           </div>
-          <span className="text-xs">
+
+          <span className="text-xs flex-shrink-0 mb-2">
             {currentXp}/{maxXp}
           </span>
         </div>


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- 분리된 유저 정보 엔드포인트 연동 및 닉네임 UI 대응

## ✨ 변경 사항 (Changes)

- 로그인/회원가입/콜백 시 유저 상세 정보(코인, 레벨 등) 자동 호출 로직 추가
- 백엔드 coins를 프론트엔드 기존 규격인 coin으로 매핑하여 하위 호환성 유지
- 닉네임이 길어질 경우 텍스트 크기를 자동으로 조절하는 ScalableText 적용
- Zustand 내 불필요한 하드코딩 기본값 제거 및 상태 업데이트 로직 강화

## 📸 스크린샷 (Screenshots)

<img width="1822" height="1107" alt="image" src="https://github.com/user-attachments/assets/44ac9a0f-41c8-43cc-9119-d471e16c35b3" />

## ✅ 리뷰어 체크리스트 (Reviewer Checklist)

- [ ] 코드가 문제없이 빌드되고 실행되는가?
- [ ] 코드 스타일 컨벤션을 준수하는가?
- [ ] 불필요한 로그나 주석이 없는가?
- [ ] 관련 문서(README 등)가 업데이트되었는가?

## 📢 참고 사항 (Notes)

- 생략합니다.

## 🧐 이슈 (Related Issues)

- Closes #177
